### PR TITLE
Add tested standard Isotropic/Anisotropic rock classes

### DIFF
--- a/src/rsr/Make/files
+++ b/src/rsr/Make/files
@@ -12,4 +12,10 @@ phaseModels/basicIncompressiblePhase/basicIncompressiblePhases.C
 phaseModels/phase/CompressiblePhase/CompressiblePhases.C
 phaseModels/blackoilPhase/blackoilPhases.C
 
+rockModels/rock/IsoRock/IsoRocks.C
+rockModels/basicIsotropicRock/basicIsotropicRocks.C
+
+rockModels/rock/DiagAnisoRock/DiagAnisoRocks.C
+rockModels/basicDiagAnisotropicRock/basicDiagAnisotropicRocks.C
+
 LIB = $(FOAM_USER_LIBBIN)/libRSR

--- a/src/rsr/include/IsotropyTypes.H
+++ b/src/rsr/include/IsotropyTypes.H
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    IsotropicDimentionedField
+
+Description
+    Isotropy/Anisotropy Types with identical construction interface
+    
+    - Isotropic: Identical field in all directions
+    - Anisotropic: Tensorial representation of field changes per direction
+    - DiagAnisotropic: Diagonal tensor representation of field changes
+                       per main-axis direction
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef IsotropyTypes_H
+#define IsotropyTypes_H
+
+#include "UniformDimensionedField.H"
+#include "pTraits.H"
+#include "volFields.H"
+#include "fvMesh.H"
+#include "uniformDimensionedFields.H"
+#include "volFieldsFwd.H"
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+// Isotropic
+using Isotropic = volScalarField;
+
+//- DiagAnisotropic
+using DiagAnisotropic = volVectorField;
+
+//- Anisotropic
+using Anisotropic = volTensorField;
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/rsr/rockModels/basicDiagAnisotropicRock/basicDiagAnisotropicRock.C
+++ b/src/rsr/rockModels/basicDiagAnisotropicRock/basicDiagAnisotropicRock.C
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "basicDiagAnisotropicRock.H"
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+template<class CompressibilityType>
+Foam::rocks::basicDiagAnisotropicRock<CompressibilityType>::
+basicDiagAnisotropicRock
+(
+    const word& name,
+    const fvMesh& mesh,
+    const dictionary& rockProperties
+)
+:
+    DiagAnisoRock<CompressibilityType>(name, mesh, rockProperties)
+{
+}
+
+
+template<class CompressibilityType>
+Foam::rocks::basicDiagAnisotropicRock<CompressibilityType>::
+basicDiagAnisotropicRock
+(
+    const basicDiagAnisotropicRock& rk
+)
+:
+    DiagAnisoRock<CompressibilityType>(rk)
+{
+}
+
+// * * * * * * * * * * * * * * * * Destructor  * * * * * * * * * * * * * * * //
+
+template<class CompressibilityType>
+Foam::rocks::basicDiagAnisotropicRock<CompressibilityType>::
+~basicDiagAnisotropicRock() {}
+
+// * * * * * * * * * * * * * Public Member Functions * * * * * * * * * * * * //
+
+template<class CompressibilityType>
+void Foam::rocks::basicDiagAnisotropicRock<CompressibilityType>::correct()
+{
+    // TODO: Do absolutely nothing
+    // TODO: Or maybe update compressibility based on pressure
+    // Alternative: Update compressibility using Hall's Correlation
+}
+
+// ************************************************************************* //

--- a/src/rsr/rockModels/basicDiagAnisotropicRock/basicDiagAnisotropicRock.H
+++ b/src/rsr/rockModels/basicDiagAnisotropicRock/basicDiagAnisotropicRock.H
@@ -1,0 +1,107 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::basicDiagAnisotropicRock
+
+Description
+    Standard implementation of anisotropic rock class where permeability is
+    expressed as a diagonal tensor
+
+SourceFiles
+    basicDiagAnisotropicRock.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef basicDiagAnisotropicRock_H
+#define basicDiagAnisotropicRock_H
+
+#include "DiagAnisoRock.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+namespace rocks
+{
+
+/*---------------------------------------------------------------------------*\
+                   Class basicDiagAnisotropicRock Declaration
+\*---------------------------------------------------------------------------*/
+
+template<class CompressibilityType>
+class basicDiagAnisotropicRock
+:
+    public DiagAnisoRock<CompressibilityType>
+{
+public:
+
+    //- Runtime type information
+    ClassName("diagAnisotropic");
+
+
+    // Constructors
+
+        // Construct from components
+        basicDiagAnisotropicRock
+        (
+            const word& name,
+            const fvMesh& mesh,
+            const dictionary& rockProperties
+        );
+
+        // Construct from copy
+        basicDiagAnisotropicRock (const basicDiagAnisotropicRock&);
+
+	// Destructor
+	virtual ~basicDiagAnisotropicRock();
+
+    // Member Functions
+
+		//- Phase fields update
+		virtual void correct() override;
+
+    // Member operators
+
+        //- Disallow default bitwise assignment
+        basicDiagAnisotropicRock& operator=(const basicDiagAnisotropicRock&) = delete;
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace phases
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#ifdef NoRepository
+    #include "basicDiagAnisotropicRock.C"
+#endif
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/rsr/rockModels/basicDiagAnisotropicRock/basicDiagAnisotropicRocks.C
+++ b/src/rsr/rockModels/basicDiagAnisotropicRock/basicDiagAnisotropicRocks.C
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "addToRunTimeSelectionTable.H"
+#include "basicDiagAnisotropicRock.H"
+#include "rocks.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+    makeDiagAnisoRockType(basicDiagAnisotropicRock, Incompressible, rocks);
+    makeDiagAnisoRockType(basicDiagAnisotropicRock, Compressible, rocks);
+}
+
+// ************************************************************************* //

--- a/src/rsr/rockModels/basicIsotropicRock/basicIsotropicRock.C
+++ b/src/rsr/rockModels/basicIsotropicRock/basicIsotropicRock.C
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "basicIsotropicRock.H"
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+template<class CompressibilityType>
+Foam::rocks::basicIsotropicRock<CompressibilityType>::basicIsotropicRock
+(
+    const word& name,
+    const fvMesh& mesh,
+    const dictionary& rockProperties
+)
+:
+    IsoRock<CompressibilityType>(name, mesh, rockProperties)
+{
+}
+
+
+template<class CompressibilityType>
+Foam::rocks::basicIsotropicRock<CompressibilityType>::basicIsotropicRock
+(
+    const basicIsotropicRock& rk
+)
+:
+    IsoRock<CompressibilityType>(rk)
+{
+}
+
+// * * * * * * * * * * * * * * * * Destructor  * * * * * * * * * * * * * * * //
+
+template<class CompressibilityType>
+Foam::rocks::basicIsotropicRock<CompressibilityType>::
+~basicIsotropicRock() {}
+
+// * * * * * * * * * * * * * Public Member Functions * * * * * * * * * * * * //
+
+template<class CompressibilityType>
+void Foam::rocks::basicIsotropicRock<CompressibilityType>::correct()
+{
+    // TODO: Do absolutely nothing
+    // TODO: Or maybe update compressibility based on pressure
+    // Alternative: Update compressibility using Hall's Correlation
+}
+
+// ************************************************************************* //

--- a/src/rsr/rockModels/basicIsotropicRock/basicIsotropicRock.H
+++ b/src/rsr/rockModels/basicIsotropicRock/basicIsotropicRock.H
@@ -1,0 +1,106 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::basicIsotropicRock
+
+Description
+    Standard implementation of an isotropic rock class
+
+SourceFiles
+    basicIsotropicRock.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef basicIsotropicRock_H
+#define basicIsotropicRock_H
+
+#include "IsoRock.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+namespace rocks
+{
+
+/*---------------------------------------------------------------------------*\
+                   Class basicIsotropicRock Declaration
+\*---------------------------------------------------------------------------*/
+
+template<class CompressibilityType>
+class basicIsotropicRock
+:
+    public IsoRock<CompressibilityType>
+{
+public:
+
+    //- Runtime type information
+    ClassName("isotropic");
+
+
+    // Constructors
+
+        // Construct from components
+        basicIsotropicRock
+        (
+            const word& name,
+            const fvMesh& mesh,
+            const dictionary& rockProperties
+        );
+
+        // Construct from copy
+        basicIsotropicRock (const basicIsotropicRock&);
+
+	// Destructor
+	virtual ~basicIsotropicRock();
+
+    // Member Functions
+
+		//- Phase fields update
+		virtual void correct() override;
+
+    // Member operators
+
+        //- Disallow default bitwise assignment
+        basicIsotropicRock& operator=(const basicIsotropicRock&) = delete;
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace phases
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#ifdef NoRepository
+    #include "basicIsotropicRock.C"
+#endif
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/rsr/rockModels/basicIsotropicRock/basicIsotropicRocks.C
+++ b/src/rsr/rockModels/basicIsotropicRock/basicIsotropicRocks.C
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "addToRunTimeSelectionTable.H"
+#include "basicIsotropicRock.H"
+#include "rocks.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+    makeIsoRockType(basicIsotropicRock, Incompressible, rocks);
+    makeIsoRockType(basicIsotropicRock, Compressible, rocks);
+}
+
+// ************************************************************************* //

--- a/src/rsr/rockModels/rock/DiagAnisoRock/DiagAnisoRock.C
+++ b/src/rsr/rockModels/rock/DiagAnisoRock/DiagAnisoRock.C
@@ -1,0 +1,94 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "DiagAnisoRock.H"
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+template<class CompressibilityType>
+Foam::autoPtr<Foam::DiagAnisoRock<CompressibilityType>>
+Foam::DiagAnisoRock<CompressibilityType>::New
+(
+    const word& name,
+    const fvMesh& mesh,
+    const dictionary& rockProperties
+)
+{
+    const word rockType = rockProperties.subDict(name).lookupOrDefault<word>
+    (
+      "rockType",
+      "diagAnisotropic"
+    );
+
+    typename dictionaryConstructorTable::iterator cstrIter =
+        dictionaryConstructorTablePtr_->find(rockType);
+
+    if (cstrIter == dictionaryConstructorTablePtr_->end())
+    {
+        FatalErrorInFunction
+            << "Unknown DiagAnisotropic Rock type "
+            << rockType << nl << nl
+            << "Valid DiagAnisotropic Rock types:" << endl
+            << dictionaryConstructorTablePtr_->sortedToc()
+            << exit(FatalError);
+    }
+
+    return autoPtr<DiagAnisoRock>
+    ( cstrIter()(name, mesh, rockProperties) );
+}
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+template<class CompressibilityType>
+Foam::DiagAnisoRock<CompressibilityType>::DiagAnisoRock
+(
+    const word& name,
+    const fvMesh& mesh,
+    const dictionary& rockProperties
+)
+:
+    rock<DiagAnisotropic, CompressibilityType>(name, mesh, rockProperties)
+{
+}
+
+
+template<class CompressibilityType>
+Foam::DiagAnisoRock<CompressibilityType>::DiagAnisoRock
+(
+    const DiagAnisoRock& rk
+)
+:
+    rock<DiagAnisotropic, CompressibilityType>(rk)
+{
+}
+
+
+// * * * * * * * * * * * * * * * * Destructor  * * * * * * * * * * * * * * * //
+
+template<class CompressibilityType>
+Foam::DiagAnisoRock<CompressibilityType>::~DiagAnisoRock()
+{}
+
+// ************************************************************************* //

--- a/src/rsr/rockModels/rock/DiagAnisoRock/DiagAnisoRock.H
+++ b/src/rsr/rockModels/rock/DiagAnisoRock/DiagAnisoRock.H
@@ -1,0 +1,124 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::DiagAnisoRock
+
+Description
+    A template base class for aniostropic rocks where absoluet permeability
+    is expressed as a normalized diagonal tensor.
+
+SourceFiles
+    DiagAnisoRock.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef DiagAnisoRock_H
+#define DiagAnisoRock_H
+
+#include "UniformityTypes.H"
+#include "IsotropyTypes.H"
+#include "rock.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+/*---------------------------------------------------------------------------*\
+                        Class DiagAnisoRock Declaration
+\*---------------------------------------------------------------------------*/
+
+template<class CompressiblityType>
+class DiagAnisoRock
+:
+    public rock<DiagAnisotropic, CompressiblityType>
+{
+public:
+    
+    //- Runtime type information
+    TypeName("DiagAnisoRock");
+
+    // Declare run-time constructor selection table
+    declareRunTimeSelectionTable
+    (
+        autoPtr,
+        DiagAnisoRock,
+        dictionary,
+        (
+            const word& name,
+            const fvMesh& mesh,
+            const dictionary& rockProperties
+        ),
+        (name, mesh, rockProperties)
+    );
+
+    // Constructors
+
+        // Construct from components
+        DiagAnisoRock
+        (
+            const word& name,
+            const fvMesh& mesh,
+            const dictionary& rockProperties
+        );
+
+        // Construct from copy
+        DiagAnisoRock (const DiagAnisoRock&);
+
+    // Selectors
+
+        //- Return a reference to the selected DiagAnisoRock
+        static autoPtr<DiagAnisoRock> New
+        (
+            const word& name,
+            const fvMesh& mesh,
+            const dictionary& rockProperties
+        );
+
+
+    //- Destructor
+    virtual ~DiagAnisoRock();
+
+    // Member Operators
+
+        //- Disallow default bitwise assignment
+        DiagAnisoRock& operator=(const DiagAnisoRock&) = delete;
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#ifdef NoRepository
+    #include "DiagAnisoRock.C"
+#endif
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/rsr/rockModels/rock/DiagAnisoRock/DiagAnisoRocks.C
+++ b/src/rsr/rockModels/rock/DiagAnisoRock/DiagAnisoRocks.C
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "rocks.H"
+#include "DiagAnisoRock.H"
+#include "addToRunTimeSelectionTable.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+#define defineDiagAnisoRockType(dataType)                                      \
+    defineNamedTemplateTypeNameAndDebug(DiagAnisoRock<dataType >, 0);          \
+    defineTemplatedRunTimeSelectionTable                                       \
+    (                                                                          \
+        DiagAnisoRock,                                                         \
+        dictionary,                                                            \
+        dataType                                                               \
+    );
+
+// Define Phases
+defineDiagAnisoRockType(Incompressible);
+defineDiagAnisoRockType(Compressible);
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// ************************************************************************* //

--- a/src/rsr/rockModels/rock/IsoRock/IsoRock.C
+++ b/src/rsr/rockModels/rock/IsoRock/IsoRock.C
@@ -1,0 +1,94 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "IsoRock.H"
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+template<class CompressibilityType>
+Foam::autoPtr<Foam::IsoRock<CompressibilityType>>
+Foam::IsoRock<CompressibilityType>::New
+(
+    const word& name,
+    const fvMesh& mesh,
+    const dictionary& rockProperties
+)
+{
+    const word rockType = rockProperties.subDict(name).lookupOrDefault<word>
+    (
+      "rockType",
+      "isotropic"
+    );
+
+    typename dictionaryConstructorTable::iterator cstrIter =
+        dictionaryConstructorTablePtr_->find(rockType);
+
+    if (cstrIter == dictionaryConstructorTablePtr_->end())
+    {
+        FatalErrorInFunction
+            << "Unknown Isotropic Rock type "
+            << rockType << nl << nl
+            << "Valid Isotropic Rock types:" << endl
+            << dictionaryConstructorTablePtr_->sortedToc()
+            << exit(FatalError);
+    }
+
+    return autoPtr<IsoRock>
+    ( cstrIter()(name, mesh, rockProperties) );
+}
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+template<class CompressibilityType>
+Foam::IsoRock<CompressibilityType>::IsoRock
+(
+    const word& name,
+    const fvMesh& mesh,
+    const dictionary& rockProperties
+)
+:
+    rock<Isotropic, CompressibilityType>(name, mesh, rockProperties)
+{
+}
+
+
+template<class CompressibilityType>
+Foam::IsoRock<CompressibilityType>::IsoRock
+(
+    const IsoRock& rk
+)
+:
+    rock<Isotropic, CompressibilityType>(rk)
+{
+}
+
+
+// * * * * * * * * * * * * * * * * Destructor  * * * * * * * * * * * * * * * //
+
+template<class CompressibilityType>
+Foam::IsoRock<CompressibilityType>::~IsoRock()
+{}
+
+// ************************************************************************* //

--- a/src/rsr/rockModels/rock/IsoRock/IsoRock.H
+++ b/src/rsr/rockModels/rock/IsoRock/IsoRock.H
@@ -1,0 +1,123 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::IsoRock
+
+Description
+    A template base class for iostropic rocks.
+
+SourceFiles
+    IsoRock.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef IsoRock_H
+#define IsoRock_H
+
+#include "UniformityTypes.H"
+#include "IsotropyTypes.H"
+#include "rock.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+/*---------------------------------------------------------------------------*\
+                           Class IsoRock Declaration
+\*---------------------------------------------------------------------------*/
+
+template<class CompressiblityType>
+class IsoRock
+:
+    public rock<Isotropic, CompressiblityType>
+{
+public:
+    
+    //- Runtime type information
+    TypeName("IsoRock");
+
+    // Declare run-time constructor selection table
+    declareRunTimeSelectionTable
+    (
+        autoPtr,
+        IsoRock,
+        dictionary,
+        (
+            const word& name,
+            const fvMesh& mesh,
+            const dictionary& rockProperties
+        ),
+        (name, mesh, rockProperties)
+    );
+
+    // Constructors
+
+        // Construct from components
+        IsoRock
+        (
+            const word& name,
+            const fvMesh& mesh,
+            const dictionary& rockProperties
+        );
+
+        // Construct from copy
+        IsoRock (const IsoRock&);
+
+    // Selectors
+
+        //- Return a reference to the selected IsoRock
+        static autoPtr<IsoRock> New
+        (
+            const word& name,
+            const fvMesh& mesh,
+            const dictionary& rockProperties
+        );
+
+
+    //- Destructor
+    virtual ~IsoRock();
+
+    // Member Operators
+
+        //- Disallow default bitwise assignment
+        IsoRock& operator=(const IsoRock&) = delete;
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#ifdef NoRepository
+    #include "IsoRock.C"
+#endif
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/rsr/rockModels/rock/IsoRock/IsoRocks.C
+++ b/src/rsr/rockModels/rock/IsoRock/IsoRocks.C
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "rocks.H"
+#include "IsoRock.H"
+#include "addToRunTimeSelectionTable.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+#define defineIsoRockType(dataType)                                            \
+    defineNamedTemplateTypeNameAndDebug(IsoRock<dataType >, 0);                \
+    defineTemplatedRunTimeSelectionTable                                       \
+    (                                                                          \
+        IsoRock,                                                               \
+        dictionary,                                                            \
+        dataType                                                               \
+    );
+
+// Define Phases
+defineIsoRockType(Incompressible);
+defineIsoRockType(Compressible);
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// ************************************************************************* //

--- a/src/rsr/rockModels/rock/rock.C
+++ b/src/rsr/rockModels/rock/rock.C
@@ -1,0 +1,125 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "rock.H"
+#include "fixedValueFvsPatchField.H"
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+template<class PermeabilityType, class CompressibilityType>
+Foam::rock<PermeabilityType, CompressibilityType>::rock
+(
+    const word& name,
+    const fvMesh& mesh,
+    const dictionary& rockProperties
+)
+:
+    regIOobject
+    (
+        IOobject
+        (
+            name,
+            mesh.time().constant(),
+            mesh,
+            IOobject::NO_READ,
+            IOobject::NO_WRITE
+        )
+    ),
+    name_(name),
+    rockDict_(rockProperties.subDict(name)),
+    mesh_(mesh),
+    poroInit_("porosity", dimless, rockDict_),
+    permInit_("permeability", dimArea, rockDict_),
+    compInit_("compressibility", (dimless/dimPressure), rockDict_),
+    porosity_
+    (
+        IOobject
+        (
+            name+".porosity",
+            mesh.time().timeName(),
+            mesh,
+            IOobject::READ_IF_PRESENT,
+            IOobject::AUTO_WRITE
+        ),
+        mesh,
+        poroInit_
+    ),
+    K_
+    (
+        IOobject
+        (
+            name+".permeability",
+            mesh.time().timeName(),
+            mesh,
+            IOobject::READ_IF_PRESENT,
+            IOobject::AUTO_WRITE
+        ),
+        mesh,
+        permInit_
+    ),
+    c_
+    (
+        IOobject
+        (
+            name+".compressibility",
+            mesh.time().timeName(),
+            mesh,
+            IOobject::READ_IF_PRESENT,
+            IOobject::AUTO_WRITE
+        ),
+        mesh,
+        compInit_
+    )
+{
+}
+
+
+template<class PermeabilityType, class CompressibilityType>
+Foam::rock<PermeabilityType, CompressibilityType>::rock
+(
+    const rock& rk
+)
+:
+    regIOobject(rk),
+    name_(rk.name_),
+    rockDict_(rk.rockDict_),
+    mesh_(rk.mesh_),
+    poroInit_(rk.poroInit_),
+    permInit_(rk.permInit_),
+    compInit_(rk.compInit_),
+    porosity_(rk.porosity_),
+    K_(rk.K_),
+    c_(rk.c_)
+{
+}
+
+
+// * * * * * * * * * * * * * * * * Destructor  * * * * * * * * * * * * * * * //
+
+template<class PermeabilityType, class CompressibilityType>
+Foam::rock<PermeabilityType, CompressibilityType>::~rock()
+{}
+
+// ************************************************************************* //

--- a/src/rsr/rockModels/rock/rock.H
+++ b/src/rsr/rockModels/rock/rock.H
@@ -1,0 +1,187 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.orgfavorable texture is depicted by favorable texture is depicted by packaging of packaging of 
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::rock
+
+Description
+    A template base class for reservoir rocks, with pressure-dependent
+    compressibility and anisotropic media support
+
+SourceFiles
+    rock.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef rock_H
+#define rock_H
+
+#include "DimensionedField.H"
+#include "GeometricField.H"
+#include "regIOobject.H"
+#include "UniformityTypes.H"
+#include "IsotropyTypes.H"
+#include "volFieldsFwd.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+/*---------------------------------------------------------------------------*\
+                             Class rock Declaration
+\*---------------------------------------------------------------------------*/
+
+template<class PermeabilityType, class CompressibilityType>
+class rock
+:
+    public regIOobject
+{
+public:
+    
+    // Public Data Types
+    
+        // Permeability field component type
+        using KcmptType = typename PermeabilityType::value_type;
+
+        // Compressibility field component type
+        using CcmptType = typename CompressibilityType::cmptType;
+
+protected:
+
+    // Protected Data
+
+        //- Rock name
+        word name_;
+
+        //- Rock Dict
+        dictionary rockDict_;
+
+        //- Const access to the mesh
+        const fvMesh& mesh_;
+
+        //- Initial porosity
+        dimensionedScalar poroInit_;
+
+        //- Initial Permeability
+        dimensioned<KcmptType> permInit_;
+
+        //- Initial Compressibility
+        dimensioned<CcmptType> compInit_;
+
+        //- Rock porosity field
+        volScalarField porosity_;
+
+        //- Rock absolute-permeability field
+        PermeabilityType K_;
+
+        //- Rock Compressibility field
+        CompressibilityType c_;
+
+public:
+
+    //- Runtime type information
+    ClassName("rock");
+
+    // Constructors
+
+        // Construct from components
+        rock
+        (
+            const word& name,
+            const fvMesh& mesh,
+            const dictionary& rockProperties
+        );
+
+        // Construct from copy
+        rock (const rock&);
+
+
+    //- Destructor
+    virtual ~rock();
+
+
+    // Member Functions
+
+        //- Return rock name
+        const word& name() const {
+            return name_;
+        }
+
+        //- Return rock dictionary
+        const dictionary& dict() const {
+            return rockDict_;
+        }
+
+        //- Return const-access to rock mesh
+        const fvMesh& mesh() const {
+            return mesh_;
+        }
+
+        //- Return const-ref to porosity field
+        const volScalarField& porosity() const {
+            return porosity_;
+        }
+        
+        //- Return const-ref to absolute permeability field
+        const PermeabilityType& K() const {
+            return K_;
+        }
+
+        //- Return const-ref to compressibility field
+        const CompressibilityType& Cf() {
+            return c_;
+        }
+
+        //- Write rock data to Ostream
+        virtual bool writeData(Ostream&) const override
+        {
+            NotImplemented;
+            return false;
+        }
+
+        //- Correct rock fields
+        virtual void correct() = 0;
+
+    // Member Operators
+
+        //- Disallow default bitwise assignment
+        rock& operator=(const rock&) = delete;
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#ifdef NoRepository
+    #include "rock.C"
+#endif
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/rsr/rockModels/rock/rocks.H
+++ b/src/rsr/rockModels/rock/rocks.H
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef rocks_H
+#define rocks_H
+
+#include "UniformityTypes.H"
+#include "debug.H"
+#include "rock.H"
+#include "typeInfo.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+// Only used internally
+#define makeTypeRocksTypeName(typeRock, dataType)                              \
+                                                                               \
+    defineNamedTemplateTypeNameAndDebug(typeRock<dataType>, 0)
+
+// Sometimes used externally
+#define makeRocksTypeName(typeRock)                                            \
+                                                                               \
+    makeTypeRocksTypeName(typeRock, UnifromMu);                                \
+    makeTypeRocksTypeName(typeRock, ChangingMu);
+
+#define makeIsoRockType(typeRock, dataType, ns)                                \
+                                                                               \
+    defineNamedTemplateTypeNameAndDebug                                        \
+    (                                                                          \
+        ns::typeRock<dataType>, 0                                              \
+    );                                                                         \
+    namespace ns {                                                             \
+    addTemplatedToRunTimeSelectionTable                                        \
+    (                                                                          \
+        IsoRock, typeRock, dataType, dictionary                                \
+    );                                                                         \
+    }
+
+#define makeDiagAnisoRockType(typeRock, dataType, ns)                          \
+                                                                               \
+    defineNamedTemplateTypeNameAndDebug                                        \
+    (                                                                          \
+        ns::typeRock<dataType>, 0                                              \
+    );                                                                         \
+    namespace ns {                                                             \
+    addTemplatedToRunTimeSelectionTable                                        \
+    (                                                                          \
+        DiagAnisoRock, typeRock, dataType, dictionary                          \
+    );                                                                         \
+    }
+
+#endif
+
+// ************************************************************************* //

--- a/tests/rsr/Make/files
+++ b/tests/rsr/Make/files
@@ -1,3 +1,5 @@
+rockModels/basicDiagAnisotropicRockTest.C
+
 phaseModels/blackoilPhaseTest.C
 phaseModels/phaseTest.C
 

--- a/tests/rsr/rockModels/basicDiagAnisotropicRockTest.C
+++ b/tests/rsr/rockModels/basicDiagAnisotropicRockTest.C
@@ -1,0 +1,75 @@
+#include "UniformityTypes.H"
+#include "autoPtr.H"
+#include "catch.H"
+#include "dimensionedScalarFwd.H"
+#include "fvCFD.H"
+#include "error.H"
+#include "rock.H"
+#include "DiagAnisoRock.H"
+#include "volFieldsFwd.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+
+using namespace Foam;
+
+SCENARIO("Rock objection creation for diagonalTensor-Permeability","[Virtual]")
+{
+    GIVEN("Valid mesh and rockProperties dictionary with porosity,"
+            " permeability and compressibility values")
+    {
+        #include "createTestTimeAndMesh.H"
+
+        word rockName = "rock";
+
+        dictionary rockDict;
+        rockDict.add<dimensionedScalar>
+        (
+            "porosity",
+            dimensionedScalar( rockName+".porosity", dimless, 0.2)
+        );
+        rockDict.add<dimensionedVector>
+        (
+            "permeability",
+            dimensioned<vector>
+            (
+                rockName+".permeability", dimArea,
+                vector(1e-12, 2e-12, 5e-15)
+            )
+        );
+        rockDict.add<dimensionedScalar>
+        (
+            "compressibility",
+            dimensionedScalar
+            (
+                rockName+".compressibility", dimless/dimPressure, 1e-6
+            )
+        );
+
+        dictionary rockProperties;
+        rockProperties.add(rockName, rockDict);
+
+        WHEN("Constructing the default rock object")
+        {
+            FatalError.dontThrowExceptions();
+            // Needs the presence of '0/water.U' dictionary
+            auto rockPtr = DiagAnisoRock<Incompressible>::New
+            (
+                rockName,
+                mesh,
+                rockProperties
+            );
+
+            THEN("Members must be initialized correctly")
+            {
+                CHECK(rockPtr->Cf().value() == 1e-6);
+                CHECK(rockPtr->porosity()[0] == 0.2);
+                CHECK(rockPtr->K()[0] == vector(1e-12, 2e-12, 5e-15));
+            }
+            FatalError.throwExceptions();
+        }
+
+    }
+}
+
+// ************************************************************************* //


### PR DESCRIPTION
This PR adds first-try implementations for isotropic and anisotropic rock classes, omitting the actual rock-related field updates.

Expected rock filed updates include (Decision on the specific method to use for standard rock classes is postponed until the first solver takes shape):
 - Porosity as a function of pressure
 - Compressibility and (potentially) Absolute Permeability as a function of Porosity