### PR TITLE
Working "volatile" dimensioned fields

### DIFF
--- a/src/rsr/Make/options
+++ b/src/rsr/Make/options
@@ -1,4 +1,5 @@
 EXE_INC = \
+    --std=c++14 \
     -I$(LIB_SRC)/OpenFOAM/lnInclude \
     -I$(LIB_SRC)/finiteVolume/lnInclude
 

--- a/src/rsr/fields/VolatileDimensionedFields/VolatileDimensionedField/VolatileDimensionedField.C
+++ b/src/rsr/fields/VolatileDimensionedFields/VolatileDimensionedField/VolatileDimensionedField.C
@@ -1,0 +1,379 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "VolatileDimensionedField.H"
+#include "dimensionedType.H"
+#include "Field.H"
+#include "VolatileDimensionedFieldReuseFunctions.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+template<class Type, class GeoMesh>
+VolatileDimensionedField<Type, GeoMesh>::VolatileDimensionedField
+(
+    const IOobject& io,
+    const Mesh& mesh,
+    const dimensionSet& dims,
+    const Field<Type>& field
+)
+:
+    DimensionedField<Type, GeoMesh>(io, mesh, dims, field),
+    mask_(GeoMesh::size(mesh) == 1 ? 0 : -1)
+{
+}
+
+
+template<class Type, class GeoMesh>
+VolatileDimensionedField<Type, GeoMesh>::VolatileDimensionedField
+(
+    const IOobject& io,
+    const Mesh& mesh,
+    const dimensionSet& dims,
+    const bool checkIOFlags
+)
+:
+    DimensionedField<Type, GeoMesh>(io, mesh, dims, checkIOFlags),
+    mask_(GeoMesh::size(mesh) == 1 ? 0 : -1)
+{
+}
+
+
+template<class Type, class GeoMesh>
+VolatileDimensionedField<Type, GeoMesh>::VolatileDimensionedField
+(
+    const IOobject& io,
+    const Mesh& mesh,
+    const dimensioned<Type>& dt,
+    const bool checkIOFlags
+)
+:
+    DimensionedField<Type, GeoMesh>(io, mesh, dt, checkIOFlags),
+    mask_(GeoMesh::size(mesh) == 1 ? 0 : -1)
+{
+}
+
+
+template<class Type, class GeoMesh>
+VolatileDimensionedField<Type, GeoMesh>::VolatileDimensionedField
+(
+    const VolatileDimensionedField<Type, GeoMesh>& df
+)
+:
+    DimensionedField<Type, GeoMesh>(df),
+    mask_(GeoMesh::size(df.mesh()) == 1 ? 0 : -1)
+{}
+
+
+template<class Type, class GeoMesh>
+VolatileDimensionedField<Type, GeoMesh>::VolatileDimensionedField
+(
+    VolatileDimensionedField<Type, GeoMesh>& df,
+    bool reuse
+)
+:
+    DimensionedField<Type, GeoMesh>(df, reuse),
+    mask_(GeoMesh::size(df.mesh()) == 1 ? 0 : -1)
+{}
+
+
+template<class Type, class GeoMesh>
+VolatileDimensionedField<Type, GeoMesh>::VolatileDimensionedField
+(
+    VolatileDimensionedField<Type, GeoMesh>&& df
+)
+:
+    DimensionedField<Type, GeoMesh>(df),
+    mask_(move(df.mask_))
+{}
+
+
+template<class Type, class GeoMesh>
+VolatileDimensionedField<Type, GeoMesh>::VolatileDimensionedField
+(
+    const tmp<VolatileDimensionedField<Type, GeoMesh>>& tdf
+)
+:
+    DimensionedField<Type, GeoMesh>(tdf()),
+    mask_(GeoMesh::size(this->mesh()) == 1 ? 0 : -1)
+{
+    tdf.clear();
+}
+
+
+template<class Type, class GeoMesh>
+VolatileDimensionedField<Type, GeoMesh>::VolatileDimensionedField
+(
+    const IOobject& io,
+    const VolatileDimensionedField<Type, GeoMesh>& df
+)
+:
+    DimensionedField<Type, GeoMesh>(io, df),
+    mask_(df.mask())
+{}
+
+
+template<class Type, class GeoMesh>
+VolatileDimensionedField<Type, GeoMesh>::VolatileDimensionedField
+(
+    const IOobject& io,
+    VolatileDimensionedField<Type, GeoMesh>& df,
+    bool reuse
+)
+:
+    DimensionedField<Type, GeoMesh>(io, df, reuse),
+    mask_(df.mask())
+{}
+
+
+template<class Type, class GeoMesh>
+VolatileDimensionedField<Type, GeoMesh>::VolatileDimensionedField
+(
+    const word& newName,
+    const VolatileDimensionedField<Type, GeoMesh>& df
+)
+:
+    DimensionedField<Type, GeoMesh>(newName, df),
+    mask_(df.mask())
+{}
+
+
+template<class Type, class GeoMesh>
+VolatileDimensionedField<Type, GeoMesh>::VolatileDimensionedField
+(
+    const word& newName,
+    VolatileDimensionedField<Type, GeoMesh>& df,
+    bool reuse
+)
+:
+    DimensionedField<Type, GeoMesh>(newName, df, reuse),
+    mask_(df.mask())
+{}
+
+
+template<class Type, class GeoMesh>
+VolatileDimensionedField<Type, GeoMesh>::VolatileDimensionedField
+(
+    const word& newName,
+    const tmp<VolatileDimensionedField<Type, GeoMesh>>& tdf
+)
+:
+    DimensionedField<Type, GeoMesh>(newName, tdf()),
+    mask_(GeoMesh::size(this->mesh()) == 1 ? 0 : -1)
+{
+    tdf.clear();
+}
+
+
+template<class Type, class GeoMesh>
+tmp<VolatileDimensionedField<Type, GeoMesh>>
+VolatileDimensionedField<Type, GeoMesh>::clone() const
+{
+    return tmp<VolatileDimensionedField<Type, GeoMesh>>
+    (
+        new VolatileDimensionedField<Type, GeoMesh>(*this)
+    );
+}
+
+
+template<class Type, class GeoMesh>
+Foam::tmp<Foam::VolatileDimensionedField<Type, GeoMesh>>
+VolatileDimensionedField<Type, GeoMesh>::New
+(
+    const word& name,
+    const Mesh& mesh,
+    const dimensionSet& ds
+)
+{
+    return tmp<VolatileDimensionedField<Type, GeoMesh>>
+    (
+        new VolatileDimensionedField<Type, GeoMesh>
+        (
+            IOobject
+            (
+                name,
+                mesh.time().timeName(),
+                mesh,
+                IOobject::NO_READ,
+                IOobject::NO_WRITE,
+                false
+            ),
+            mesh,
+            ds,
+            false
+        )
+    );
+}
+
+
+template<class Type, class GeoMesh>
+Foam::tmp<Foam::VolatileDimensionedField<Type, GeoMesh>>
+VolatileDimensionedField<Type, GeoMesh>::New
+(
+    const word& name,
+    const Mesh& mesh,
+    const dimensioned<Type>& dt
+)
+{
+    return tmp<VolatileDimensionedField<Type, GeoMesh>>
+    (
+        new VolatileDimensionedField<Type, GeoMesh>
+        (
+            IOobject
+            (
+                name,
+                mesh.time().timeName(),
+                mesh,
+                IOobject::NO_READ,
+                IOobject::NO_WRITE,
+                false
+            ),
+            mesh,
+            dt,
+            false
+        )
+    );
+}
+
+
+template<class Type, class GeoMesh>
+Foam::tmp<Foam::VolatileDimensionedField<Type, GeoMesh>>
+VolatileDimensionedField<Type, GeoMesh>::New
+(
+    const word& newName,
+    const VolatileDimensionedField<Type, GeoMesh>& df
+)
+{
+    return tmp<VolatileDimensionedField<Type, GeoMesh>>
+    (
+        new VolatileDimensionedField<Type, GeoMesh>
+        (
+            IOobject
+            (
+                newName,
+                df.instance(),
+                df.local(),
+                df.db(),
+                IOobject::NO_READ,
+                IOobject::NO_WRITE,
+                false
+            ),
+            df
+        )
+    );
+}
+
+
+template<class Type, class GeoMesh>
+Foam::tmp<Foam::VolatileDimensionedField<Type, GeoMesh>>
+VolatileDimensionedField<Type, GeoMesh>::New
+(
+    const word& newName,
+    const tmp<VolatileDimensionedField<Type, GeoMesh>>& tdf
+)
+{
+    return tmp<VolatileDimensionedField<Type, GeoMesh>>
+    (
+        new VolatileDimensionedField<Type, GeoMesh>
+        (
+            IOobject
+            (
+                newName,
+                tdf().instance(),
+                tdf().local(),
+                tdf().db(),
+                IOobject::NO_READ,
+                IOobject::NO_WRITE,
+                false
+            ),
+            tdf
+        )
+    );
+}
+
+// * * * * * * * * * * * * * * * * Destructor  * * * * * * * * * * * * * * * //
+
+template<class Type, class GeoMesh>
+VolatileDimensionedField<Type, GeoMesh>::~VolatileDimensionedField()
+{}
+
+
+// * * * * * * * * * * * * * * * Member Operators  * * * * * * * * * * * * * //
+
+MEMBER_PRODUCT_OPERATOR(typeOfSum, +, Plus, add, VolatileDimensionedField)
+MEMBER_PRODUCT_OPERATOR(typeOfSum, -, Minus,subtract, VolatileDimensionedField)
+MEMBER_PRODUCT_OPERATOR(outerProduct, *, Star, outer, VolatileDimensionedField)
+MEMBER_PRODUCT_OPERATOR(crossProduct, ^, Cross,cross, VolatileDimensionedField)
+MEMBER_PRODUCT_OPERATOR(innerProduct, &, Inner, dot, VolatileDimensionedField)
+MEMBER_PRODUCT_OPERATOR(scalarProduct,&&,Scalar,dotdot,VolatileDimensionedField)
+
+TMP_PRODUCT_OPERATOR
+(
+    typeOfSum, +, Plus, add,
+    VolatileDimensionedField, VolatileDimensionedField
+)
+TMP_PRODUCT_OPERATOR
+(
+    typeOfSum, -, Minus, subtract,
+    VolatileDimensionedField, VolatileDimensionedField
+)
+TMP_PRODUCT_OPERATOR
+(
+    outerProduct, *, Star, outer,
+    VolatileDimensionedField, VolatileDimensionedField
+)
+TMP_PRODUCT_OPERATOR
+(
+    crossProduct, ^, Cross, cross,
+    VolatileDimensionedField, VolatileDimensionedField
+)
+TMP_PRODUCT_OPERATOR
+(
+    innerProduct, &, Inner, dot,
+    VolatileDimensionedField, VolatileDimensionedField
+)
+TMP_PRODUCT_OPERATOR
+(
+    scalarProduct, &&, Scalar, dotdot,
+    VolatileDimensionedField, VolatileDimensionedField
+)
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#undef checkField
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#include "VolatileDimensionedFieldIO.C"
+
+// ************************************************************************* //

--- a/src/rsr/fields/VolatileDimensionedFields/VolatileDimensionedField/VolatileDimensionedField.H
+++ b/src/rsr/fields/VolatileDimensionedFields/VolatileDimensionedField/VolatileDimensionedField.H
@@ -1,0 +1,362 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::VolatileDimensionedField
+
+Description
+    A field with dimensions. Can be instantiated on a single-cell mesh or
+    on a regular volume mesh. Mainly for optimized operations between
+    dimensioned fields and uniform-like ones.
+
+SourceFiles
+    VolatileDimensionedFieldI.H
+    VolatileDimensionedField.C
+    VolatileDimensionedFieldIO.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef VolatileDimensionedField_H
+#define VolatileDimensionedField_H
+
+#include "DimensionedField.H"
+#include "VolatileDimensionedFieldM.H"
+#include "products.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+// Forward declaration of friend functions and operators
+
+template<class Type, class GeoMesh> class VolatileDimensionedField;
+
+template<class Type, class GeoMesh> Ostream& operator<<
+(
+    Ostream&,
+    const VolatileDimensionedField<Type, GeoMesh>&
+);
+
+template<class Type, class GeoMesh> Ostream& operator<<
+(
+    Ostream&,
+    const tmp<VolatileDimensionedField<Type, GeoMesh>>&
+);
+
+/*---------------------------------------------------------------------------*\
+                           Class VolatileDimensionedField Declaration
+\*---------------------------------------------------------------------------*/
+
+template<class Type, class GeoMesh>
+class VolatileDimensionedField
+:
+    public DimensionedField<Type, GeoMesh>
+{
+
+public:
+
+    // Public Typedefs
+
+        //- Type of mesh on which this VolatileDimensionedField is instantiated
+        typedef typename GeoMesh::Mesh Mesh;
+
+        //- Type of the field from which this VolatileDimensionedField is derived
+        typedef Field<Type> FieldType;
+
+        //- Component type of the elements of the field
+        typedef typename Field<Type>::cmptType cmptType;
+
+
+private:
+
+    // Private Data
+
+        //- A mask to decide on how much space to allocate for field values
+        label mask_;
+
+public:
+
+    //- Runtime type information
+    ClassName("VolatileDimensionedField");
+
+    // Constructors
+
+        //- Construct from components
+        VolatileDimensionedField
+        (
+            const IOobject&,
+            const Mesh& mesh,
+            const dimensionSet&,
+            const Field<Type>&
+        );
+
+        //- Construct from components
+        //  Used for temporary fields which are initialised after construction
+        VolatileDimensionedField
+        (
+            const IOobject&,
+            const Mesh& mesh,
+            const dimensionSet&,
+            const bool checkIOFlags = true
+        );
+
+        //- Construct from components
+        VolatileDimensionedField
+        (
+            const IOobject&,
+            const Mesh& mesh,
+            const dimensioned<Type>&,
+            const bool checkIOFlags = true
+        );
+
+        //- Construct from Istream
+        VolatileDimensionedField
+        (
+            const IOobject&,
+            const Mesh& mesh,
+            const word& fieldDictEntry="value"
+        );
+
+        //- Construct from dictionary
+        VolatileDimensionedField
+        (
+            const IOobject&,
+            const Mesh& mesh,
+            const dictionary& fieldDict,
+            const word& fieldDictEntry="value"
+        );
+
+        //- Copy constructor
+        VolatileDimensionedField
+        (
+            const VolatileDimensionedField<Type, GeoMesh>&
+        );
+
+        //- Copy constructor or re-use as specified.
+        VolatileDimensionedField
+        (
+            VolatileDimensionedField<Type, GeoMesh>&,
+            bool reuse
+        );
+
+        //- Move constructor
+        VolatileDimensionedField
+        (
+            VolatileDimensionedField<Type, GeoMesh>&&
+        );
+
+        //- Copy constructor of tmp<VolatileDimensionedField> deleting argument
+        VolatileDimensionedField
+        (
+            const tmp<VolatileDimensionedField<Type, GeoMesh>>&
+        );
+
+        //- Copy constructor resetting IO parameters
+        VolatileDimensionedField
+        (
+            const IOobject&,
+            const VolatileDimensionedField<Type, GeoMesh>&
+        );
+
+        //- Copy constructor resetting IO parameters and re-use as specified.
+        VolatileDimensionedField
+        (
+            const IOobject&,
+            VolatileDimensionedField<Type, GeoMesh>&,
+            bool reuse
+        );
+
+        //- Copy constructor resetting name
+        VolatileDimensionedField
+        (
+            const word& newName,
+            const VolatileDimensionedField<Type, GeoMesh>&
+        );
+
+        //- Copy constructor resetting name and re-use as specified.
+        VolatileDimensionedField
+        (
+            const word& newName,
+            VolatileDimensionedField<Type, GeoMesh>&,
+            bool reuse
+        );
+
+        //- Copy constructor resetting name
+        VolatileDimensionedField
+        (
+            const word& newName,
+            const tmp<VolatileDimensionedField<Type, GeoMesh>>&
+        );
+
+        //- Clone
+        tmp<VolatileDimensionedField<Type, GeoMesh>> clone() const;
+
+        //- Return a temporary field constructed from name, mesh
+        //  and dimensionSet
+        static tmp<VolatileDimensionedField<Type, GeoMesh>> New
+        (
+            const word& name,
+            const Mesh& mesh,
+            const dimensionSet&
+        );
+
+        //- Return a temporary field constructed from name, mesh
+        //  and dimensionType providing dimensions and value
+        static tmp<VolatileDimensionedField<Type, GeoMesh>> New
+        (
+            const word& name,
+            const Mesh& mesh,
+            const dimensioned<Type>&
+        );
+
+        //- Return a temporary field constructed from name and a field
+        static tmp<VolatileDimensionedField<Type, GeoMesh>> New
+        (
+            const word& newName,
+            const VolatileDimensionedField<Type, GeoMesh>&
+        );
+
+        //- Return renamed temporary field
+        static tmp<VolatileDimensionedField<Type, GeoMesh>> New
+        (
+            const word& newName,
+            const tmp<VolatileDimensionedField<Type, GeoMesh>>&
+        );
+
+
+    //- Destructor
+    virtual ~VolatileDimensionedField();
+
+
+    // Member Functions
+
+        //- Return mask
+        inline const label& mask() const
+        {
+            return mask_;
+        }
+
+    // Member Operators
+
+        // Access to field elements
+        Type& operator[](const label& index)
+        {
+            return DimensionedField<Type, GeoMesh>::operator[]( index & mask_);
+        }
+
+        // Const-access to field elements
+        const Type& operator[](const label& index) const
+        {
+            return DimensionedField<Type, GeoMesh>::operator[]( index & mask_);
+        }
+
+        // Product operators using operator between field elements
+        MEMBER_PRODUCT_OPERATOR_DECL
+        (
+            typeOfSum, +, add, VolatileDimensionedField
+        );
+        MEMBER_PRODUCT_OPERATOR_DECL
+        (
+            typeOfSum, -, subtract, VolatileDimensionedField
+        );
+        MEMBER_PRODUCT_OPERATOR_DECL
+        (
+            outerProduct, *, outer, VolatileDimensionedField
+        );
+        MEMBER_PRODUCT_OPERATOR_DECL
+        (
+            crossProduct, ^, cross, VolatileDimensionedField
+        );
+        MEMBER_PRODUCT_OPERATOR_DECL
+        (
+            innerProduct, &, dot, VolatileDimensionedField
+        );
+        MEMBER_PRODUCT_OPERATOR_DECL
+        (
+            scalarProduct, &&, dotdot, VolatileDimensionedField
+        );
+
+
+    // Ostream Operators
+
+        friend Ostream& operator<< <Type, GeoMesh>
+        (
+            Ostream&,
+            const VolatileDimensionedField<Type, GeoMesh>&
+        );
+
+        friend Ostream& operator<< <Type, GeoMesh>
+        (
+            Ostream&,
+            const tmp<VolatileDimensionedField<Type, GeoMesh>>&
+        );
+
+};
+
+TMP_PRODUCT_OPERATOR_DECL
+(
+    typeOfSum, +, Plus, add,
+    VolatileDimensionedField, VolatileDimensionedField
+);
+TMP_PRODUCT_OPERATOR_DECL
+(
+    typeOfSum, -, Minus, subtract,
+    VolatileDimensionedField, VolatileDimensionedField
+);
+TMP_PRODUCT_OPERATOR_DECL
+(
+    outerProduct, *, Star, outer,
+    VolatileDimensionedField, VolatileDimensionedField
+);
+TMP_PRODUCT_OPERATOR_DECL
+(
+    crossProduct, ^, Cross, cross,
+    VolatileDimensionedField, VolatileDimensionedField
+);
+TMP_PRODUCT_OPERATOR_DECL
+(
+    innerProduct, &, Inner, dot,
+    VolatileDimensionedField, VolatileDimensionedField
+);
+TMP_PRODUCT_OPERATOR_DECL
+(
+    scalarProduct, &&, Scalar, dotdot,
+    VolatileDimensionedField, VolatileDimensionedField
+);
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#ifdef NoRepository
+    #include "VolatileDimensionedField.C"
+#endif
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/rsr/fields/VolatileDimensionedFields/VolatileDimensionedField/VolatileDimensionedFieldFunctionsM.C
+++ b/src/rsr/fields/VolatileDimensionedFields/VolatileDimensionedField/VolatileDimensionedFieldFunctionsM.C
@@ -1,0 +1,683 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "VolatileDimensionedFieldReuseFunctions.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+/*
+#define UNARY_FUNCTION(ReturnType, Type1, Func, Dfunc)                         \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> Func                                \
+(                                                                              \
+    const VolatileDimensionedField<Type1, GeoMesh>& df1                                \
+)                                                                              \
+{                                                                              \
+    tmp<VolatileDimensionedField<ReturnType, GeoMesh>> tRes                            \
+    (                                                                          \
+        VolatileDimensionedField<ReturnType, GeoMesh>::New                             \
+        (                                                                      \
+            #Func "(" + df1.name() + ')',                                      \
+            df1.mesh(),                                                        \
+            Dfunc(df1.dimensions())                                            \
+        )                                                                      \
+    );                                                                         \
+                                                                               \
+    Func(tRes.ref().field(), df1.field());                                     \
+                                                                               \
+    return tRes;                                                               \
+}                                                                              \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> Func                                \
+(                                                                              \
+    const tmp<VolatileDimensionedField<Type1, GeoMesh>>& tdf1                          \
+)                                                                              \
+{                                                                              \
+    const VolatileDimensionedField<Type1, GeoMesh>& df1 = tdf1();                      \
+                                                                               \
+    tmp<VolatileDimensionedField<ReturnType, GeoMesh>> tRes                            \
+    (                                                                          \
+        reuseTmpVolatileDimensionedField<ReturnType, Type1, GeoMesh>::New              \
+        (                                                                      \
+            tdf1,                                                              \
+            #Func "(" + df1.name() + ')',                                      \
+            Dfunc(df1.dimensions())                                            \
+        )                                                                      \
+    );                                                                         \
+                                                                               \
+    Func(tRes.ref().field(), df1.field());                                     \
+                                                                               \
+    tdf1.clear();                                                              \
+                                                                               \
+    return tRes;                                                               \
+}
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#define UNARY_OPERATOR(ReturnType, Type1, Op, OpFunc, Dfunc)                   \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> operator Op                         \
+(                                                                              \
+    const VolatileDimensionedField<Type1, GeoMesh>& df1                                \
+)                                                                              \
+{                                                                              \
+    tmp<VolatileDimensionedField<ReturnType, GeoMesh>> tRes                            \
+    (                                                                          \
+        VolatileDimensionedField<ReturnType, GeoMesh>::New                             \
+        (                                                                      \
+            #Op + df1.name(),                                                  \
+            df1.mesh(),                                                        \
+            Dfunc(df1.dimensions())                                            \
+        )                                                                      \
+    );                                                                         \
+                                                                               \
+    Foam::OpFunc(tRes.ref().field(), df1.field());                             \
+                                                                               \
+    return tRes;                                                               \
+}                                                                              \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> operator Op                         \
+(                                                                              \
+    const tmp<VolatileDimensionedField<Type1, GeoMesh>>& tdf1                          \
+)                                                                              \
+{                                                                              \
+    const VolatileDimensionedField<Type1, GeoMesh>& df1 = tdf1();                      \
+                                                                               \
+    tmp<VolatileDimensionedField<ReturnType, GeoMesh>> tRes                            \
+    (                                                                          \
+        reuseTmpVolatileDimensionedField<ReturnType, Type1, GeoMesh>::New              \
+        (                                                                      \
+            tdf1,                                                              \
+            #Op + df1.name(),                                                  \
+            Dfunc(df1.dimensions())                                            \
+        )                                                                      \
+    );                                                                         \
+                                                                               \
+    Foam::OpFunc(tRes.ref().field(), df1.field());                             \
+                                                                               \
+    tdf1.clear();                                                              \
+                                                                               \
+    return tRes;                                                               \
+}
+*/
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#define BINARY_FUNCTION(ReturnType, Type1, Type2, Func)                        \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> Func                                \
+(                                                                              \
+    const VolatileDimensionedField<Type1, GeoMesh>& df1,                               \
+    const VolatileDimensionedField<Type2, GeoMesh>& df2                                \
+)                                                                              \
+{                                                                              \
+    tmp<VolatileDimensionedField<ReturnType, GeoMesh>> tRes                            \
+    (                                                                          \
+        VolatileDimensionedField<ReturnType, GeoMesh>::New                             \
+        (                                                                      \
+            #Func "(" + df1.name() + ',' + df2.name() + ')',                   \
+            df1.mask() ? df1.mesh() : df2.mesh(),                              \
+            Func(df1.dimensions(), df2.dimensions())                           \
+        )                                                                      \
+    );                                                                         \
+                                                                               \
+    /*Func(tRes.ref().field(), df1.field(), df2.field());*/                        \
+    forAll(tRes(), ci) \
+    {\
+        tRes.ref()[ci] = Func(df1[ci], df2[ci]);\
+    }\
+                                                                               \
+    return tRes;                                                               \
+}                                                                              \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> Func                                \
+(                                                                              \
+    const VolatileDimensionedField<Type1, GeoMesh>& df1,                               \
+    const tmp<VolatileDimensionedField<Type2, GeoMesh>>& tdf2                          \
+)                                                                              \
+{                                                                              \
+    const VolatileDimensionedField<Type2, GeoMesh>& df2 = tdf2();                      \
+                                                                               \
+    tmp<VolatileDimensionedField<ReturnType, GeoMesh>> tRes                            \
+    (                                                                          \
+        reuseTmpVolatileDimensionedField<ReturnType, Type2, GeoMesh>::New              \
+        (                                                                      \
+            tdf2,                                                              \
+            #Func "(" + df1.name() + ',' + df2.name() + ')',                   \
+            Func(df1.dimensions(), df2.dimensions())                           \
+        )                                                                      \
+    );                                                                         \
+                                                                               \
+    /*Func(tRes.ref().field(), df1.field(), df2.field());*/                        \
+    forAll(tRes(), ci) \
+    {\
+        tRes.ref()[ci] = Func(df1[ci], df2[ci]);\
+    }\
+                                                                               \
+    tdf2.clear();                                                              \
+                                                                               \
+    return tRes;                                                               \
+}                                                                              \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> Func                                \
+(                                                                              \
+    const tmp<VolatileDimensionedField<Type1, GeoMesh>>& tdf1,                         \
+    const VolatileDimensionedField<Type2, GeoMesh>& df2                                \
+)                                                                              \
+{                                                                              \
+    const VolatileDimensionedField<Type1, GeoMesh>& df1 = tdf1();                      \
+                                                                               \
+    tmp<VolatileDimensionedField<ReturnType, GeoMesh>> tRes                            \
+    (                                                                          \
+        reuseTmpVolatileDimensionedField<ReturnType, Type1, GeoMesh>::New              \
+        (                                                                      \
+            tdf1,                                                              \
+            #Func "(" + df1.name() + ',' + df2.name() + ')',                   \
+            Func(df1.dimensions(), df2.dimensions())                           \
+        )                                                                      \
+    );                                                                         \
+                                                                               \
+    /*Func(tRes.ref().field(), df1.field(), df2.field());*/                        \
+    forAll(tRes(), ci) \
+    {\
+        tRes.ref()[ci] = Func(df1[ci], df2[ci]);\
+    }\
+                                                                               \
+    tdf1.clear();                                                              \
+                                                                               \
+    return tRes;                                                               \
+}                                                                              \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> Func                                \
+(                                                                              \
+    const tmp<VolatileDimensionedField<Type1, GeoMesh>>& tdf1,                         \
+    const tmp<VolatileDimensionedField<Type2, GeoMesh>>& tdf2                          \
+)                                                                              \
+{                                                                              \
+    const VolatileDimensionedField<Type1, GeoMesh>& df1 = tdf1();                      \
+    const VolatileDimensionedField<Type2, GeoMesh>& df2 = tdf2();                      \
+                                                                               \
+    tmp<VolatileDimensionedField<ReturnType, GeoMesh>> tRes                            \
+    (                                                                          \
+        reuseTmpTmpVolatileDimensionedField                                            \
+            <ReturnType, Type1, Type1, Type2, GeoMesh>::New                    \
+        (                                                                      \
+            tdf1,                                                              \
+            tdf2,                                                              \
+            #Func "(" + df1.name() + ',' + df2.name() + ')',                   \
+            Func(df1.dimensions(), df2.dimensions())                           \
+        )                                                                      \
+    );                                                                         \
+                                                                               \
+    /*Func(tRes.ref().field(), df1.field(), df2.field());*/                        \
+    forAll(tRes(), ci) \
+    {\
+        tRes.ref()[ci] = Func(df1[ci], df2[ci]);\
+    }\
+                                                                               \
+    tdf1.clear();                                                              \
+    tdf2.clear();                                                              \
+                                                                               \
+    return tRes;                                                               \
+}
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+/*
+#define BINARY_TYPE_FUNCTION_SF(ReturnType, Type1, Type2, Func)                \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> Func                                \
+(                                                                              \
+    const dimensioned<Type1>& dt1,                                             \
+    const VolatileDimensionedField<Type2, GeoMesh>& df2                                \
+)                                                                              \
+{                                                                              \
+    tmp<VolatileDimensionedField<ReturnType, GeoMesh>> tRes                            \
+    (                                                                          \
+        VolatileDimensionedField<ReturnType, GeoMesh>::New                             \
+        (                                                                      \
+            #Func "(" + dt1.name() + ',' + df2.name() + ')',                   \
+            df2.mesh(),                                                        \
+            Func(dt1.dimensions(), df2.dimensions())                           \
+        )                                                                      \
+    );                                                                         \
+                                                                               \
+    Func(tRes.ref().field(), dt1.value(), df2.field());                        \
+                                                                               \
+    return tRes;                                                               \
+}                                                                              \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> Func                                \
+(                                                                              \
+    const Type1& t1,                                                           \
+    const VolatileDimensionedField<Type2, GeoMesh>& df2                                \
+)                                                                              \
+{                                                                              \
+    return Func(dimensioned<Type1>(t1), df2);                                  \
+}                                                                              \
+                                                                               \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> Func                                \
+(                                                                              \
+    const dimensioned<Type1>& dt1,                                             \
+    const tmp<VolatileDimensionedField<Type2, GeoMesh>>& tdf2                          \
+)                                                                              \
+{                                                                              \
+    const VolatileDimensionedField<Type2, GeoMesh>& df2 = tdf2();                      \
+                                                                               \
+    tmp<VolatileDimensionedField<ReturnType, GeoMesh>> tRes                            \
+    (                                                                          \
+        reuseTmpVolatileDimensionedField<ReturnType, Type2, GeoMesh>::New              \
+        (                                                                      \
+            tdf2,                                                              \
+            #Func "(" + dt1.name() + ',' + df2.name() + ')',                   \
+            Func(dt1.dimensions(), df2.dimensions())                           \
+        )                                                                      \
+    );                                                                         \
+                                                                               \
+    Func(tRes.ref().field(), dt1.value(), df2.field());                        \
+                                                                               \
+    tdf2.clear();                                                              \
+                                                                               \
+    return tRes;                                                               \
+}                                                                              \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> Func                                \
+(                                                                              \
+    const Type1& t1,                                                           \
+    const tmp<VolatileDimensionedField<Type2, GeoMesh>>& tdf2                          \
+)                                                                              \
+{                                                                              \
+    return Func(dimensioned<Type2>(t1), tdf2);                                 \
+}
+*/
+
+/*
+#define BINARY_TYPE_FUNCTION_FS(ReturnType, Type1, Type2, Func)                \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> Func                                \
+(                                                                              \
+    const VolatileDimensionedField<Type1, GeoMesh>& df1,                               \
+    const dimensioned<Type2>& dt2                                              \
+)                                                                              \
+{                                                                              \
+    tmp<VolatileDimensionedField<ReturnType, GeoMesh>> tRes                            \
+    (                                                                          \
+        VolatileDimensionedField<ReturnType, GeoMesh>::New                             \
+        (                                                                      \
+            #Func "(" + df1.name() + ',' + dt2.name() + ')',                   \
+            df1.mesh(),                                                        \
+            Func(df1.dimensions(), dt2.dimensions())                           \
+        )                                                                      \
+    );                                                                         \
+                                                                               \
+    Func(tRes.ref().field(), df1.field(), dt2.value());                        \
+                                                                               \
+    return tRes;                                                               \
+}                                                                              \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> Func                                \
+(                                                                              \
+    const VolatileDimensionedField<Type1, GeoMesh>& df1,                               \
+    const Type2& t2                                                            \
+)                                                                              \
+{                                                                              \
+    return Func(df1, dimensioned<Type2>(t2));                                  \
+}                                                                              \
+                                                                               \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> Func                                \
+(                                                                              \
+    const tmp<VolatileDimensionedField<Type1, GeoMesh>>& tdf1,                         \
+    const dimensioned<Type2>& dt2                                              \
+)                                                                              \
+{                                                                              \
+    const VolatileDimensionedField<Type1, GeoMesh>& df1 = tdf1();                      \
+                                                                               \
+    tmp<VolatileDimensionedField<ReturnType, GeoMesh>> tRes                            \
+    (                                                                          \
+        reuseTmpVolatileDimensionedField<ReturnType, Type1, GeoMesh>::New              \
+        (                                                                      \
+            tdf1,                                                              \
+            #Func "(" + df1.name() + ',' + dt2.name() + ')',                   \
+            Func(df1.dimensions(), dt2.dimensions())                           \
+        )                                                                      \
+    );                                                                         \
+                                                                               \
+    Func(tRes.ref().field(), df1.field(), dt2.value());                        \
+                                                                               \
+    tdf1.clear();                                                              \
+                                                                               \
+    return tRes;                                                               \
+}                                                                              \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> Func                                \
+(                                                                              \
+    const tmp<VolatileDimensionedField<Type1, GeoMesh>>& tdf1,                         \
+    const Type2& t2                                                            \
+)                                                                              \
+{                                                                              \
+    return Func(tdf1, dimensioned<Type2>(t2));                                 \
+}
+
+
+#define BINARY_TYPE_FUNCTION(ReturnType, Type1, Type2, Func)                   \
+    BINARY_TYPE_FUNCTION_SF(ReturnType, Type1, Type2, Func)                    \
+    BINARY_TYPE_FUNCTION_FS(ReturnType, Type1, Type2, Func)
+
+*/
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#define BINARY_OPERATOR(ReturnType, Type1, Type2, Op, OpName, OpFunc)          \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> operator Op                         \
+(                                                                              \
+    const VolatileDimensionedField<Type1, GeoMesh>& df1,                               \
+    const VolatileDimensionedField<Type2, GeoMesh>& df2                                \
+)                                                                              \
+{                                                                              \
+    tmp<VolatileDimensionedField<ReturnType, GeoMesh>> tRes                            \
+    (                                                                          \
+        VolatileDimensionedField<ReturnType, GeoMesh>::New                             \
+        (                                                                      \
+            '(' + df1.name() + OpName + df2.name() + ')',                      \
+            df1.mask() ? df1.mesh() : df2.mesh(),                                                        \
+            df1.dimensions() Op df2.dimensions()                               \
+        )                                                                      \
+    );                                                                         \
+                                                                               \
+    /*Foam::OpFunc(tRes.ref().field(), df1.field(), df2.field());*/                \
+    forAll(tRes(), ci) \
+    {\
+        tRes.ref()[ci] = OpFunc(df1[ci], df2[ci]);\
+    }\
+                                                                               \
+    return tRes;                                                               \
+}                                                                              \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> operator Op                         \
+(                                                                              \
+    const VolatileDimensionedField<Type1, GeoMesh>& df1,                               \
+    const tmp<VolatileDimensionedField<Type2, GeoMesh>>& tdf2                          \
+)                                                                              \
+{                                                                              \
+    const VolatileDimensionedField<Type2, GeoMesh>& df2 = tdf2();                      \
+                                                                               \
+    tmp<VolatileDimensionedField<ReturnType, GeoMesh>> tRes                            \
+    (                                                                          \
+        reuseTmpVolatileDimensionedField<ReturnType, Type2, GeoMesh>::New              \
+        (                                                                      \
+            tdf2,                                                              \
+            '(' + df1.name() + OpName + df2.name() + ')',                      \
+            df1.dimensions() Op df2.dimensions()                               \
+        )                                                                      \
+    );                                                                         \
+                                                                               \
+    /*Foam::OpFunc(tRes.ref().field(), df1.field(), df2.field());*/                \
+    forAll(tRes(), ci) \
+    {\
+        tRes.ref()[ci] = Foam::OpFunc(df1[ci], df2[ci]);\
+    }\
+                                                                               \
+    tdf2.clear();                                                              \
+                                                                               \
+    return tRes;                                                               \
+}                                                                              \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> operator Op                         \
+(                                                                              \
+    const tmp<VolatileDimensionedField<Type1, GeoMesh>>& tdf1,                         \
+    const VolatileDimensionedField<Type2, GeoMesh>& df2                                \
+)                                                                              \
+{                                                                              \
+    const VolatileDimensionedField<Type1, GeoMesh>& df1 = tdf1();                      \
+                                                                               \
+    tmp<VolatileDimensionedField<ReturnType, GeoMesh>> tRes                            \
+    (                                                                          \
+        reuseTmpVolatileDimensionedField<ReturnType, Type1, GeoMesh>::New              \
+        (                                                                      \
+            tdf1,                                                              \
+            '(' + df1.name() + OpName + df2.name() + ')',                      \
+            df1.dimensions() Op df2.dimensions()                               \
+        )                                                                      \
+    );                                                                         \
+                                                                               \
+    /*Foam::OpFunc(tRes.ref().field(), df1.field(), df2.field());*/                \
+    forAll(tRes(), ci) \
+    {\
+        tRes.ref()[ci] = Foam::OpFunc(df1[ci], df2[ci]);\
+    }\
+                                                                               \
+    tdf1.clear();                                                              \
+                                                                               \
+    return tRes;                                                               \
+}                                                                              \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> operator Op                         \
+(                                                                              \
+    const tmp<VolatileDimensionedField<Type1, GeoMesh>>& tdf1,                         \
+    const tmp<VolatileDimensionedField<Type2, GeoMesh>>& tdf2                          \
+)                                                                              \
+{                                                                              \
+    const VolatileDimensionedField<Type1, GeoMesh>& df1 = tdf1();                      \
+    const VolatileDimensionedField<Type2, GeoMesh>& df2 = tdf2();                      \
+                                                                               \
+    tmp<VolatileDimensionedField<ReturnType, GeoMesh>> tRes                            \
+    (                                                                          \
+        reuseTmpTmpVolatileDimensionedField                                            \
+            <ReturnType, Type1, Type1, Type2, GeoMesh>::New                    \
+        (                                                                      \
+            tdf1,                                                              \
+            tdf2,                                                              \
+            '(' + df1.name() + OpName + df2.name() + ')',                      \
+            df1.dimensions() Op df2.dimensions()                               \
+        )                                                                      \
+    );                                                                         \
+                                                                               \
+    /*Foam::OpFunc(tRes.ref().field(), df1.field(), df2.field());*/                \
+    forAll(tRes(), ci) \
+    {\
+        tRes.ref()[ci] = Foam::OpFunc(df1[ci], df2[ci]);\
+    }\
+                                                                               \
+    tdf1.clear();                                                              \
+    tdf2.clear();                                                              \
+                                                                               \
+    return tRes;                                                               \
+}
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+/*
+#define BINARY_TYPE_OPERATOR_SF(ReturnType, Type1, Type2, Op, OpName, OpFunc) \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> operator Op                         \
+(                                                                              \
+    const dimensioned<Type1>& dt1,                                             \
+    const VolatileDimensionedField<Type2, GeoMesh>& df2                                \
+)                                                                              \
+{                                                                              \
+    tmp<VolatileDimensionedField<ReturnType, GeoMesh>> tRes                            \
+    (                                                                          \
+        VolatileDimensionedField<ReturnType, GeoMesh>::New                             \
+        (                                                                      \
+            '(' + dt1.name() + OpName + df2.name() + ')',                      \
+            df2.mesh(),                                                        \
+            dt1.dimensions() Op df2.dimensions()                               \
+        )                                                                      \
+    );                                                                         \
+                                                                               \
+    Foam::OpFunc(tRes.ref().field(), dt1.value(), df2.field());                \
+                                                                               \
+    return tRes;                                                               \
+}                                                                              \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> operator Op                         \
+(                                                                              \
+    const Type1& t1,                                                           \
+    const VolatileDimensionedField<Type2, GeoMesh>& df2                                \
+)                                                                              \
+{                                                                              \
+    return dimensioned<Type1>(t1) Op df2;                                      \
+}                                                                              \
+                                                                               \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> operator Op                         \
+(                                                                              \
+    const dimensioned<Type1>& dt1,                                             \
+    const tmp<VolatileDimensionedField<Type2, GeoMesh>>& tdf2                          \
+)                                                                              \
+{                                                                              \
+    const VolatileDimensionedField<Type2, GeoMesh>& df2 = tdf2();                      \
+                                                                               \
+    tmp<VolatileDimensionedField<ReturnType, GeoMesh>> tRes                            \
+    (                                                                          \
+        reuseTmpVolatileDimensionedField<ReturnType, Type2, GeoMesh>::New              \
+        (                                                                      \
+            tdf2,                                                              \
+            '(' + dt1.name() + OpName + df2.name() + ')',                      \
+            dt1.dimensions() Op df2.dimensions()                               \
+        )                                                                      \
+    );                                                                         \
+                                                                               \
+    Foam::OpFunc(tRes.ref().field(), dt1.value(), tdf2().field());             \
+                                                                               \
+    tdf2.clear();                                                              \
+                                                                               \
+    return tRes;                                                               \
+}                                                                              \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> operator Op                         \
+(                                                                              \
+    const Type1& t1,                                                           \
+    const tmp<VolatileDimensionedField<Type2, GeoMesh>>& tdf2                          \
+)                                                                              \
+{                                                                              \
+    return dimensioned<Type1>(t1) Op tdf2;                                     \
+}
+
+
+#define BINARY_TYPE_OPERATOR_FS(ReturnType, Type1, Type2, Op, OpName, OpFunc) \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> operator Op                         \
+(                                                                              \
+    const VolatileDimensionedField<Type1, GeoMesh>& df1,                               \
+    const dimensioned<Type2>& dt2                                              \
+)                                                                              \
+{                                                                              \
+    tmp<VolatileDimensionedField<ReturnType, GeoMesh>> tRes                            \
+    (                                                                          \
+        VolatileDimensionedField<ReturnType, GeoMesh>::New                             \
+        (                                                                      \
+            '(' + df1.name() + OpName + dt2.name() + ')',                      \
+            df1.mesh(),                                                        \
+            df1.dimensions() Op dt2.dimensions()                               \
+        )                                                                      \
+    );                                                                         \
+                                                                               \
+    Foam::OpFunc(tRes.ref().field(), df1.field(), dt2.value());                \
+                                                                               \
+    return tRes;                                                               \
+}                                                                              \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> operator Op                         \
+(                                                                              \
+    const VolatileDimensionedField<Type1, GeoMesh>& df1,                               \
+    const Type2& t2                                                            \
+)                                                                              \
+{                                                                              \
+    return df1 Op dimensioned<Type2>(t2);                                      \
+}                                                                              \
+                                                                               \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> operator Op                         \
+(                                                                              \
+    const tmp<VolatileDimensionedField<Type1, GeoMesh>>& tdf1,                         \
+    const dimensioned<Type2>& dt2                                              \
+)                                                                              \
+{                                                                              \
+    const VolatileDimensionedField<Type1, GeoMesh>& df1 = tdf1();                      \
+                                                                               \
+    tmp<VolatileDimensionedField<ReturnType, GeoMesh>> tRes                            \
+    (                                                                          \
+        reuseTmpVolatileDimensionedField<ReturnType, Type1, GeoMesh>::New              \
+        (                                                                      \
+            tdf1,                                                              \
+            '(' + df1.name() + OpName + dt2.name() + ')',                      \
+            df1.dimensions() Op dt2.dimensions()                               \
+        )                                                                      \
+    );                                                                         \
+                                                                               \
+    Foam::OpFunc(tRes.ref().field(), tdf1().field(), dt2.value());             \
+                                                                               \
+    tdf1.clear();                                                              \
+                                                                               \
+    return tRes;                                                               \
+}                                                                              \
+                                                                               \
+TEMPLATE                                                                       \
+tmp<VolatileDimensionedField<ReturnType, GeoMesh>> operator Op                         \
+(                                                                              \
+    const tmp<VolatileDimensionedField<Type1, GeoMesh>>& tdf1,                         \
+    const Type2& t2                                                            \
+)                                                                              \
+{                                                                              \
+    return tdf1 Op dimensioned<Type2>(t2);                                     \
+}
+
+#define BINARY_TYPE_OPERATOR(ReturnType, Type1, Type2, Op, OpName, OpFunc)     \
+    BINARY_TYPE_OPERATOR_SF(ReturnType, Type1, Type2, Op, OpName, OpFunc)      \
+    BINARY_TYPE_OPERATOR_FS(ReturnType, Type1, Type2, Op, OpName, OpFunc)
+*/
+
+// ************************************************************************* //

--- a/src/rsr/fields/VolatileDimensionedFields/VolatileDimensionedField/VolatileDimensionedFieldIO.C
+++ b/src/rsr/fields/VolatileDimensionedFields/VolatileDimensionedField/VolatileDimensionedFieldIO.C
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "IOstreams.H"
+
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+template<class Type, class GeoMesh>
+Foam::VolatileDimensionedField<Type, GeoMesh>::VolatileDimensionedField
+(
+    const IOobject& io,
+    const Mesh& mesh,
+    const word& fieldDictEntry
+)
+:
+    DimensionedField<Type, GeoMesh>(io, mesh, fieldDictEntry),
+    mask_(GeoMesh::size(mesh) == 1 ? 0 : -1)
+{
+}
+
+
+template<class Type, class GeoMesh>
+Foam::VolatileDimensionedField<Type, GeoMesh>::VolatileDimensionedField
+(
+    const IOobject& io,
+    const Mesh& mesh,
+    const dictionary& fieldDict,
+    const word& fieldDictEntry
+)
+:
+    DimensionedField<Type, GeoMesh>(io, mesh, fieldDictEntry),
+    mask_(GeoMesh::size(mesh) == 1 ? 0 : -1)
+{
+}
+
+
+// * * * * * * * * * * * * * * * IOstream Operators  * * * * * * * * * * * * //
+
+template<class Type, class GeoMesh>
+Foam::Ostream& Foam::operator<<
+(
+    Ostream& os,
+    const VolatileDimensionedField<Type, GeoMesh>& df
+)
+{
+    df.writeData(os);
+
+    return os;
+}
+
+
+template<class Type, class GeoMesh>
+Foam::Ostream& Foam::operator<<
+(
+    Ostream& os,
+    const tmp<VolatileDimensionedField<Type, GeoMesh>>& tdf
+)
+{
+    tdf().writeData(os);
+    tdf.clear();
+
+    return os;
+}
+
+
+// ************************************************************************* //

--- a/src/rsr/fields/VolatileDimensionedFields/VolatileDimensionedField/VolatileDimensionedFieldM.H
+++ b/src/rsr/fields/VolatileDimensionedFields/VolatileDimensionedField/VolatileDimensionedFieldM.H
@@ -1,0 +1,201 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+InClass
+    Foam::VolatileDimensionedField
+
+Description
+    Macros for declaring and defining operators and functions for volatile
+    field operations
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef VolatileDimensionedFieldM_H
+#define VolatileDimensionedFieldM_H
+
+#include "products.H"
+#include "VolatileDimensionedFieldOpsTraitsM.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+// Check mesh for two volatile fields
+// require at least a  single-cell meshe if meshes are different
+#define checkField(df1, df2, op)                                               \
+if                                                                             \
+(                                                                              \
+    ( GeoMesh::size((df1).mesh()) != 1 )                                       \
+    and ( GeoMesh::size((df2).mesh()) != 1 )                                   \
+    and ( &(df1).mesh() != &(df2).mesh() )                                     \
+)                                                                              \
+{                                                                              \
+    FatalErrorInFunction                                                       \
+        << "Different mesh for fields "                                        \
+        << (df1).name() << " and " << (df2).name()                             \
+        << " during operation "  #op                                           \
+        << abort(FatalError);                                                  \
+}
+
+#define MEMBER_PRODUCT_OPERATOR_DECL(product, op, opFunc, fieldType)           \
+                                                                               \
+template<class Type2>                                                          \
+tmp<VolatileDimensionedField<typename product<Type, Type2>::type, GeoMesh>>    \
+operator op                                                                    \
+(                                                                              \
+    const fieldType<Type2, GeoMesh>& df2                                       \
+);                                                                             \
+                                                                               \
+template<class Type2>                                                          \
+tmp<VolatileDimensionedField<typename product<Type, Type2>::type, GeoMesh>>    \
+operator op                                                                    \
+(                                                                              \
+    const tmp<fieldType<Type2, GeoMesh>>& tdf2                                 \
+)
+
+#define MEMBER_PRODUCT_OPERATOR(product, op, opName, opFunc, fieldType)        \
+                                                                               \
+BEST_BINARY_PRODUCT(op, opName, opFunc, );                                     \
+                                                                               \
+template<class Type, class GeoMesh>                                            \
+template<class Type2>                                                          \
+tmp<VolatileDimensionedField<typename product<Type, Type2>::type, GeoMesh>>    \
+VolatileDimensionedField<Type, GeoMesh>::operator op                           \
+(                                                                              \
+    const fieldType<Type2, GeoMesh>& df2                                       \
+)                                                                              \
+{                                                                              \
+    checkField((*this), df2, op);                                              \
+    typedef typename product<Type, Type2>::type productType;                   \
+    tmp<VolatileDimensionedField<productType, GeoMesh>> tRes                   \
+    (                                                                          \
+        VolatileDimensionedField<productType, GeoMesh>::New                    \
+        (                                                                      \
+            '(' + this->name() + #op + df2.name() + ')',                       \
+            this->mask() ? this->mesh() : df2.mesh(),                          \
+            this->dimensions() op df2.dimensions()                             \
+        )                                                                      \
+    );                                                                         \
+                                                                               \
+    forAll(tRes(), ci)                                                         \
+    {                                                                          \
+        opName##Helper::opFunc##Best                                           \
+        (                                                                      \
+            tRes.ref()[ci], this->operator[](ci), df2[ci]                      \
+        );                                                                     \
+    }                                                                          \
+                                                                               \
+    return tRes;                                                               \
+}                                                                              \
+                                                                               \
+template<class Type, class GeoMesh>                                            \
+template<class Type2>                                                          \
+tmp<VolatileDimensionedField<typename product<Type, Type2>::type, GeoMesh>>    \
+VolatileDimensionedField<Type, GeoMesh>::operator op                           \
+(                                                                              \
+    const tmp<fieldType<Type2, GeoMesh>>& tdf2                                 \
+)                                                                              \
+{                                                                              \
+    checkField((*this), tdf2(), op);                                           \
+    typedef typename product<Type, Type2>::type productType;                   \
+                                                                               \
+    const VolatileDimensionedField<Type2, GeoMesh>& df2 = tdf2();              \
+                                                                               \
+    tmp<VolatileDimensionedField<productType, GeoMesh>> tRes =                 \
+        reuseTmpVolatileDimensionedField<productType, Type2, GeoMesh>::New     \
+        (                                                                      \
+            tdf2,                                                              \
+            '(' + this->name() + #op + df2.name() + ')',                       \
+            this->dimensions() op df2.dimensions()                             \
+        );                                                                     \
+                                                                               \
+    forAll(tRes(), ci)                                                         \
+    {                                                                          \
+        opName##Helper::opFunc##Best                                           \
+        (                                                                      \
+            tRes.ref()[ci], this->operator[](ci), df2[ci]                      \
+        );                                                                     \
+    }                                                                          \
+                                                                               \
+    tdf2.clear();                                                              \
+                                                                               \
+    return tRes;                                                               \
+}                                                               
+
+#define TMP_PRODUCT_OPERATOR_DECL\
+(product, op, opName, opFunc, fieldType1, fieldType2)                          \
+                                                                               \
+template<class Type1, class Type2, class GeoMesh>                              \
+tmp<VolatileDimensionedField<typename product<Type1, Type2>::type, GeoMesh>>   \
+operator op                                                                    \
+(                                                                              \
+    const tmp<fieldType1<Type1, GeoMesh>>& tdf1,                               \
+    const tmp<fieldType2<Type2, GeoMesh>>& tdf2                                \
+)                                                                           
+
+#define TMP_PRODUCT_OPERATOR\
+(product, op, opName, opFunc, fieldType1, fieldType2)                          \
+                                                                               \
+BEST_BINARY_PRODUCT(op, opName, opFunc, Tmp);                                  \
+                                                                               \
+template<class Type1, class Type2, class GeoMesh>                              \
+tmp<VolatileDimensionedField<typename product<Type1, Type2>::type, GeoMesh>>   \
+operator op                                                                    \
+(                                                                              \
+    const tmp<fieldType1<Type1, GeoMesh>>& tdf1,                               \
+    const tmp<fieldType2<Type2, GeoMesh>>& tdf2                                \
+)                                                                              \
+{                                                                              \
+    checkField(tdf1(), tdf2(), op);                                            \
+    typedef typename product<Type1, Type2>::type productType;                  \
+                                                                               \
+    const VolatileDimensionedField<Type1, GeoMesh>& df1 = tdf1();              \
+    const VolatileDimensionedField<Type2, GeoMesh>& df2 = tdf2();              \
+                                                                               \
+    tmp<VolatileDimensionedField<productType, GeoMesh>> tRes =                 \
+        reuseTmpTmpVolatileDimensionedField                                    \
+        <productType, Type1, Type1, Type2, GeoMesh>::New                       \
+        (                                                                      \
+            !df1.mask() ? tdf1 : tdf2,                                         \
+            df1.mask() ? tdf2 : tdf1,                                          \
+            '(' + df1.name() + #op + df2.name() + ')',                         \
+            df1.dimensions() op df2.dimensions()                               \
+        );                                                                     \
+                                                                               \
+    forAll(tRes(), ci)                                                         \
+    {                                                                          \
+        opName##HelperTmp::opFunc##Best                                        \
+        (                                                                      \
+            tRes.ref()[ci], df1[ci], df2[ci]                                   \
+        );                                                                     \
+    }                                                                          \
+                                                                               \
+    tdf1.clear();                                                              \
+    tdf2.clear();                                                              \
+                                                                               \
+    return tRes;                                                               \
+}                                                                              
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/rsr/fields/VolatileDimensionedFields/VolatileDimensionedField/VolatileDimensionedFieldReuseFunctions.H
+++ b/src/rsr/fields/VolatileDimensionedFields/VolatileDimensionedField/VolatileDimensionedFieldReuseFunctions.H
@@ -1,0 +1,270 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef VolatileDimensionedFieldReuseFunctions_H
+#define VolatileDimensionedFieldReuseFunctions_H
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+template<class TypeR, class GeoMesh>
+tmp<VolatileDimensionedField<TypeR, GeoMesh>> New
+(
+    const tmp<VolatileDimensionedField<TypeR, GeoMesh>>& tdf1,
+    const word& name,
+    const dimensionSet& dimensions
+)
+{
+    VolatileDimensionedField<TypeR, GeoMesh>& df1 =
+        const_cast<VolatileDimensionedField<TypeR, GeoMesh>& >(tdf1());
+
+    if (tdf1.isTmp())
+    {
+        df1.rename(name);
+        df1.dimensions().reset(dimensions);
+        return tdf1;
+    }
+    else
+    {
+        return VolatileDimensionedField<TypeR, GeoMesh>::New
+        (
+            name,
+            df1.mesh(),
+            dimensions
+        );
+    }
+}
+
+
+template<class TypeR, class Type1, class GeoMesh>
+class reuseTmpVolatileDimensionedField
+{
+public:
+
+    static tmp<VolatileDimensionedField<TypeR, GeoMesh>> New
+    (
+        const tmp<VolatileDimensionedField<Type1, GeoMesh>>& tdf1,
+        const word& name,
+        const dimensionSet& dimensions
+    )
+    {
+        const VolatileDimensionedField<Type1, GeoMesh>& df1 = tdf1();
+
+        return VolatileDimensionedField<TypeR, GeoMesh>::New
+        (
+            name,
+            df1.mesh(),
+            dimensions
+        );
+    }
+};
+
+
+template<class TypeR, class GeoMesh>
+class reuseTmpVolatileDimensionedField<TypeR, TypeR, GeoMesh>
+{
+public:
+
+    static tmp<VolatileDimensionedField<TypeR, GeoMesh>> New
+    (
+        const tmp<VolatileDimensionedField<TypeR, GeoMesh>>& tdf1,
+        const word& name,
+        const dimensionSet& dimensions
+    )
+    {
+        VolatileDimensionedField<TypeR, GeoMesh>& df1 =
+            const_cast<VolatileDimensionedField<TypeR, GeoMesh>& >(tdf1());
+
+        if (tdf1.isTmp())
+        {
+            df1.rename(name);
+            df1.dimensions().reset(dimensions);
+            return tdf1;
+        }
+        else
+        {
+            return VolatileDimensionedField<TypeR, GeoMesh>::New
+            (
+                name,
+                df1.mesh(),
+                dimensions
+            );
+        }
+    }
+};
+
+
+template<class TypeR, class Type1, class Type12, class Type2, class GeoMesh>
+class reuseTmpTmpVolatileDimensionedField
+{
+public:
+
+    static tmp<VolatileDimensionedField<TypeR, GeoMesh>> New
+    (
+        const tmp<VolatileDimensionedField<Type1, GeoMesh>>& tdf1,
+        const tmp<VolatileDimensionedField<Type2, GeoMesh>>& tdf2,
+        const word& name,
+        const dimensionSet& dimensions
+    )
+    {
+        const VolatileDimensionedField<Type1, GeoMesh>& df1 = tdf1();
+
+        return VolatileDimensionedField<TypeR, GeoMesh>::New
+        (
+            name,
+            df1.mesh(),
+            dimensions
+        );
+    }
+};
+
+
+template<class TypeR, class Type1, class Type12, class GeoMesh>
+class reuseTmpTmpVolatileDimensionedField<TypeR, Type1, Type12, TypeR, GeoMesh>
+{
+public:
+
+    static tmp<VolatileDimensionedField<TypeR, GeoMesh>> New
+    (
+        const tmp<VolatileDimensionedField<Type1, GeoMesh>>& tdf1,
+        const tmp<VolatileDimensionedField<TypeR, GeoMesh>>& tdf2,
+        const word& name,
+        const dimensionSet& dimensions
+    )
+    {
+        const VolatileDimensionedField<Type1, GeoMesh>& df1 = tdf1();
+        VolatileDimensionedField<TypeR, GeoMesh>& df2 =
+            const_cast<VolatileDimensionedField<TypeR, GeoMesh>& >(tdf2());
+
+        if (tdf2.isTmp())
+        {
+            df2.rename(name);
+            df2.dimensions().reset(dimensions);
+            return tdf2;
+        }
+        else
+        {
+            return VolatileDimensionedField<TypeR, GeoMesh>::New
+            (
+                name,
+                df1.mesh(),
+                dimensions
+            );
+        }
+    }
+};
+
+
+template<class TypeR, class Type2, class GeoMesh>
+class reuseTmpTmpVolatileDimensionedField<TypeR, TypeR, TypeR, Type2, GeoMesh>
+{
+public:
+
+    static tmp<VolatileDimensionedField<TypeR, GeoMesh>> New
+    (
+        const tmp<VolatileDimensionedField<TypeR, GeoMesh>>& tdf1,
+        const tmp<VolatileDimensionedField<Type2, GeoMesh>>& tdf2,
+        const word& name,
+        const dimensionSet& dimensions
+    )
+    {
+        VolatileDimensionedField<TypeR, GeoMesh>& df1 =
+            const_cast<VolatileDimensionedField<TypeR, GeoMesh>& >(tdf1());
+
+        if (tdf1.isTmp())
+        {
+            df1.rename(name);
+            df1.dimensions().reset(dimensions);
+            return tdf1;
+        }
+        else
+        {
+            return VolatileDimensionedField<TypeR, GeoMesh>::New
+            (
+                name,
+                df1.mesh(),
+                dimensions
+            );
+        }
+    }
+};
+
+
+template<class TypeR, class GeoMesh>
+class reuseTmpTmpVolatileDimensionedField<TypeR, TypeR, TypeR, TypeR, GeoMesh>
+{
+public:
+
+    static tmp<VolatileDimensionedField<TypeR, GeoMesh>> New
+    (
+        const tmp<VolatileDimensionedField<TypeR, GeoMesh>>& tdf1,
+        const tmp<VolatileDimensionedField<TypeR, GeoMesh>>& tdf2,
+        const word& name,
+        const dimensionSet& dimensions
+    )
+    {
+        VolatileDimensionedField<TypeR, GeoMesh>& df1 =
+            const_cast<VolatileDimensionedField<TypeR, GeoMesh>& >(tdf1());
+        VolatileDimensionedField<TypeR, GeoMesh>& df2 =
+            const_cast<VolatileDimensionedField<TypeR, GeoMesh>& >(tdf2());
+
+        if (tdf1.isTmp())
+        {
+            df1.rename(name);
+            df1.dimensions().reset(dimensions);
+            return tdf1;
+        }
+        else if (tdf2.isTmp())
+        {
+            df2.rename(name);
+            df2.dimensions().reset(dimensions);
+            return tdf2;
+        }
+        else
+        {
+            return VolatileDimensionedField<TypeR, GeoMesh>::New
+            (
+                name,
+                df1.mesh(),
+                dimensions
+            );
+        }
+    }
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/rsr/fields/VolatileDimensionedFields/VolatileDimensionedField/VolatileDimensionedFields.H
+++ b/src/rsr/fields/VolatileDimensionedFields/VolatileDimensionedField/VolatileDimensionedFields.H
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef VolatileDimensionedFields_H
+#define VolatileDimensionedFields_H
+
+//#include "VolatileDimensionedScalarField.H"
+//#include "VolatileDimensionedVectorField.H"
+//#include "VolatileDimensionedTensorField.H"
+//#include "VolatileDimensionedSphericalTensorField.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/rsr/include/VolatileDimensionedFieldOpsTraitsM.H
+++ b/src/rsr/include/VolatileDimensionedFieldOpsTraitsM.H
@@ -1,0 +1,123 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Description
+    Macros to pick the correct operations on VolatileDimensionedField
+    components.
+
+    If the expression (res = x op y) compiles, it's the preferred path.
+    Else, we use opFunc(res, x, y) if that compiles.
+    If nothing works, then, we don't know what to do and the compiler should
+    ERROR OUT.
+
+    Eg. The simple (res = x op y) may not compile because of unambiguous call
+    to 'operator op' so we fall back to the less common opFunc(res, x, y)
+
+Note
+    Particularly, we don't want to fall back to any other form of the above
+    operation because we can't trust it to "binary". Hence the compilation
+    error instead of looking for other alternatives.
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef VolatileDimensionedFieldOpsTraitsM_H
+#define VolatileDimensionedFieldOpsTraitsM_H
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#define BEST_BINARY_PRODUCT(op, opName, opFunc, helperSuffix)                  \
+                                                                               \
+struct opName##Helper##helperSuffix                                            \
+{                                                                              \
+    /* See if (result = x op y) compiles */                                    \
+    template<class rT, class T1, class T2>                                     \
+    static auto operator##opName##Works(rT& res, T1& x ,T2& y)                 \
+            -> decltype(res = x op y, std::true_type());                       \
+    static std::false_type operator##opName##Works(...);                       \
+                                                                               \
+    /* See if add(result, x, y) compiles */                                    \
+    template<class rT, class T1, class T2>                                     \
+    static auto opFunc##Works(rT& res, T1& x , T2& y)                          \
+    -> decltype(add(res, x, y), std::true_type());                             \
+    static std::false_type opFunc##Works(...);                                 \
+                                                                               \
+    /* Selector for best path to take */                                       \
+    template<class rT, class T1, class T2, bool has_op, bool has_func>         \
+    struct best##opName##Selector;                                             \
+                                                                               \
+    /* Use this if (res = x op y) compiles */                                  \
+    template<class rT, class T1, class T2, bool has_func>                      \
+    struct best##opName##Selector<rT, T1, T2, true , has_func>                 \
+    {                                                                          \
+        static auto f(rT& res, T1&x, T2& y) ->decltype(res = x op y)           \
+        {                                                                      \
+            /*Info << "x " #op " y is happening" << endl;*/                    \
+            res = x op y;                                                      \
+            return res;                                                        \
+        }                                                                      \
+    };                                                                         \
+                                                                               \
+    /* Use this if opFunc(res,x,y) compiles */                                 \
+    template<class rT, class T1, class T2>                                     \
+    struct best##opName##Selector<rT, T1, T2, false , true>                    \
+    {                                                                          \
+        static auto f(rT& res, T1&x, T2& y) -> decltype(opFunc(res, x, y))     \
+        {                                                                      \
+            /*Info << "opFunc(res, x, y) is happening" << endl;*/              \
+            return opFunc(res, x, y);                                          \
+        }                                                                      \
+    };                                                                         \
+                                                                               \
+    /* Compiler error if nothing works */                                      \
+    template<class rT, class T1, class T2>                                     \
+    struct best##opName##Selector<rT, T1, T2, false , false>                   \
+    {                                                                          \
+        static auto f(rT& res, T1&x, T2& y)                                    \
+        {                                                                      \
+            static_assert                                                      \
+            (                                                                  \
+                sizeof(rT) < 0,                                                \
+                "No overload is appropriate for operation " #opName            \
+            );                                                                 \
+            return 0;                                                          \
+        }                                                                      \
+    };                                                                         \
+                                                                               \
+    /* Call this function to automatically determine what to do */             \
+    template<class rT, class T1, class T2>                                     \
+    static auto opFunc##Best(rT& res, T1& x, T2& y)                            \
+    {                                                                          \
+        return best##opName##Selector                                          \
+            <                                                                  \
+                rT, T1, T2,                                                    \
+                decltype(operator##opName##Works(res, x, y))::value,           \
+                decltype(opFunc##Works(res, x, y))::value                      \
+            >::f(res, x, y);                                                   \
+    }                                                                          \
+}
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/tests/rsr/Make/files
+++ b/tests/rsr/Make/files
@@ -10,6 +10,9 @@ interpolations/basicInterpolationTableTest.C
 interpolations/linearScalarInterpolationTableTest.C
 interpolations/steppedScalarInterpolationTableTest.C
 
+fields/VolatileOpsTraitsMTest.C
+fields/VolatileDimensionedFieldTest.C
+
 rsrTestDriver.C
 
 EXE = rsrTestDriver

--- a/tests/rsr/Make/options
+++ b/tests/rsr/Make/options
@@ -1,4 +1,5 @@
 EXE_INC = \
+    -ggdb --std=c++14 \
     -I$(LIB_SRC)/OpenFOAM/lnInclude \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
     -I$(LIB_SRC)/meshTools/lnInclude \

--- a/tests/rsr/fields/VolatileDimensionedFieldTest.C
+++ b/tests/rsr/fields/VolatileDimensionedFieldTest.C
@@ -1,0 +1,408 @@
+#include <vector>
+#include "catch.H"
+#include "error.H"
+#include "fvCFD.H"
+#include "VolatileDimensionedField.H"
+#include "DimensionedTensorField.H"
+#include "scalar.H"
+#include "singleCellFvMesh.H"
+#include "UniformDimensionedField.H"
+#include "vector.H"
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+using namespace Foam;
+
+#define TEST_DIMENSIONED_FIELD_BINARY_OP(t1,df1,df2,op,opName)                 \
+        WHEN("Two volatile fields are " #opName)                               \
+        {                                                                      \
+            auto vdf3 = v##df1 op v##df2;                                      \
+            auto df3 = df1 op df2;                                             \
+            THEN("Operation is consistent with standard Dimensioned Fields")   \
+            {                                                                  \
+                REQUIRE                                                        \
+                (                                                              \
+                    std::vector<t1>(vdf3->begin(), vdf3->end())                \
+                    == std::vector<t1>(df3->begin(), df3->end())               \
+                );                                                             \
+            }                                                                  \
+        }
+
+
+#define TEST_DIMENSIONED_FIELD_BINARY_FUNCTION(t1,vdf1,vdf2,FuncName)          \
+        WHEN(#FuncName "(Two volatile fields)")                                \
+        {                                                                      \
+            auto vdf3 = FuncName(vdf1, vdf2);                                  \
+            auto df3 = FuncName(df1, df2);                                     \
+            THEN("Operation is consistent with standard Dimensioned Fields")   \
+            {                                                                  \
+                REQUIRE                                                        \
+                (                                                              \
+                    std::vector<t1>(vdf3->begin(), vdf3->end())                \
+                    == std::vector<t1>(df3->begin(), df3->end())               \
+                );                                                             \
+            }                                                                  \
+        }
+
+#define TEST_VOLATILE_FIELD_BINARY_OP(t1,vdf1,vdf2,op,opName)                  \
+        WHEN("Two volatile fields are " #opName)                               \
+        {                                                                      \
+            auto vdf3 = vdf1 op vdf2;                                          \
+            THEN("Operation result match expected vector")                     \
+            {                                                                  \
+                REQUIRE_THAT                                                   \
+                (                                                              \
+                    std::vector<t1>(vdf3->begin(), vdf3->end()),               \
+                    Catch::Matchers::Approx( expected##opName ).margin(1e-6)   \
+                );                                                             \
+            }                                                                  \
+        }
+
+#define TEST_TMP_DIMENSIONED_FIELD_BINARY_OP(t1,vdf1,vdf2,op1,op2,opName)      \
+        WHEN("Two temporary volatile fields are " #opName)                     \
+        {                                                                      \
+            auto vdf3 = (vdf1 op1 vdf2) op2 (vdf1 op2 vdf2);                   \
+            THEN("Operation is consistent with standard Dimensioned Fields")   \
+            {                                                                  \
+                REQUIRE_THAT                                                   \
+                (                                                              \
+                    std::vector<t1>(vdf3->begin(), vdf3->end()),               \
+                    Catch::Matchers::Approx( expectedTmp##opName ).margin(1e-6)\
+                );                                                             \
+            }                                                                  \
+        }
+
+
+SCENARIO("Compatibility of volatile fields with standard DimensionedFields"
+        " when they have the same size" )
+{
+    GIVEN("A valid mesh")
+    {
+        #include "createTestTimeAndMesh.H"
+        DimensionedField<scalar, volMesh> df1
+        (
+            IOobject
+            (
+                "df1",
+                runTime.timeName(),
+                mesh,
+                IOobject::NO_READ,
+                IOobject::NO_WRITE
+            ),
+            mesh,
+            dimensionedScalar("df", 0.0)
+        );
+        DimensionedField<scalar, volMesh> df2
+        (
+            IOobject
+            (
+                "df2",
+                runTime.timeName(),
+                mesh,
+                IOobject::NO_READ,
+                IOobject::NO_WRITE
+            ),
+            mesh,
+            dimensionedScalar("df", 0.0)
+        );
+        VolatileDimensionedField<scalar, volMesh> vdf1
+        (
+            IOobject
+            (
+                "vdf1",
+                runTime.timeName(),
+                mesh,
+                IOobject::NO_READ,
+                IOobject::NO_WRITE
+            ),
+            mesh,
+            dimensionedScalar("vdf", 0.0)
+        );
+        VolatileDimensionedField<scalar, volMesh> vdf2
+        (
+            IOobject
+            (
+                "vdf2",
+                runTime.timeName(),
+                mesh,
+                IOobject::NO_READ,
+                IOobject::NO_WRITE
+            ),
+            mesh,
+            dimensionedScalar("vdf", 0.0)
+        );
+
+        for (label i = 0; i < mesh.nCells(); ++i)
+        {
+            df1[i] = 0.1 + 15*i/mesh.nCells();
+            vdf1[i] = df1[i];
+            df2[i] = -1.1 + 20*i/mesh.nCells();
+            vdf2[i] = df2[i];
+        }
+
+        TEST_DIMENSIONED_FIELD_BINARY_OP(scalar,df1,df2,+,added)
+        TEST_DIMENSIONED_FIELD_BINARY_OP(scalar,df1,df2,+,added)
+        TEST_DIMENSIONED_FIELD_BINARY_OP(scalar,df1,df2,-,subtracted)
+        TEST_DIMENSIONED_FIELD_BINARY_OP(scalar,df1,df2,*,outer-multiplied)
+
+        TEST_DIMENSIONED_FIELD_BINARY_FUNCTION(scalar,df1,df2,pow)
+    }
+}
+
+#undef TEST_DIMENSIONED_FIELD_BINARY_OP
+#undef TEST_DIMENSIONED_FIELD_BINARY_FUNCTION
+
+SCENARIO("Operations involving Single-Cell volatile fields")
+{
+    GIVEN("A valid mesh and its single-cell version")
+    {
+        #include "createTestTimeAndMesh.H"
+        FatalError.dontThrowExceptions();
+        VolatileDimensionedField<scalar, volMesh> vdf1
+        (
+            IOobject
+            (
+                "vdf1",
+                runTime.timeName(),
+                mesh,
+                IOobject::NO_READ,
+                IOobject::NO_WRITE
+            ),
+            mesh,
+            dimensionedScalar("vdf", 0.0)
+        );
+        singleCellFvMesh singleCell
+        (
+            IOobject
+            (
+                "oneCell",
+                mesh.polyMesh::instance(),
+                mesh.time(),
+                IOobject::NO_READ,
+                IOobject::NO_WRITE
+            ),
+            mesh
+        );
+        VolatileDimensionedField<scalar, volMesh> vdf2
+        (
+            IOobject
+            (
+                "vdf2",
+                runTime.timeName(),
+                mesh,
+                IOobject::NO_READ,
+                IOobject::NO_WRITE
+            ),
+            singleCell,
+            dimensionedScalar("vdf", 0.0)
+        );
+
+        for (label i = 0; i < mesh.nCells(); ++i)
+        {
+            vdf1[i] = 0.1 + 15*i/mesh.nCells();
+        }
+        vdf2[0] = 1.6;
+
+        std::vector<scalar> expectedAdded
+        {
+            1.7, 2.7, 4.7, 5.7, 7.7, 8.7, 10.7, 11.7, 13.7, 14.7
+        };
+        std::vector<scalar> expectedSubtracted
+        {
+            -1.5, -0.5, 1.5, 2.5, 4.5, 5.5, 7.5, 8.5, 10.5, 11.5
+        };
+        std::vector<scalar> expectedSubtracted2
+        {
+            1.5, 0.5, -1.5, -2.5, -4.5, -5.5, -7.5, -8.5, -10.5, -11.5
+        };
+        std::vector<scalar> expectedMultiplied
+        {
+            0.16, 1.76, 4.96, 6.56, 9.76, 11.36, 14.56, 16.16, 19.36, 20.96
+        };
+        std::vector<scalar> expectedCrossMultiplied
+        {
+            0.16, 1.76, 4.96, 6.56, 9.76, 11.36, 14.56, 16.16, 19.36, 20.96
+        };
+
+        scalarList tmpM(expectedAdded.size());
+        for (size_t i = 0; i < expectedAdded.size(); ++i) {
+            tmpM[i] = expectedAdded[i]*expectedSubtracted[i];
+        }
+
+        TEST_VOLATILE_FIELD_BINARY_OP(scalar,vdf1,vdf2,+,Added)
+        TEST_VOLATILE_FIELD_BINARY_OP(scalar,vdf2,vdf1,+,Added)
+        TEST_VOLATILE_FIELD_BINARY_OP(scalar,vdf1,vdf2,-,Subtracted)
+        TEST_VOLATILE_FIELD_BINARY_OP(scalar,vdf2,vdf1,-,Subtracted2)
+        TEST_VOLATILE_FIELD_BINARY_OP(scalar,vdf1,vdf2,*,Multiplied)
+
+        std::vector<scalar> expectedTmpAdded
+        {
+            3.2, 3.2, 3.2, 3.2, 3.2, 3.2, 3.2, 3.2, 3.2, 3.2
+        };
+        TEST_TMP_DIMENSIONED_FIELD_BINARY_OP(scalar,vdf1,vdf2,+,-,Added)
+
+        tensor initialTensor { 0.1, 0.2, 0.3, 0.5, 0.7, 0.1, 0.5, 0.6, 0.4};
+
+        VolatileDimensionedField<tensor, volMesh> tvdf1
+        (
+            IOobject
+            (
+                "vdf2",
+                runTime.timeName(),
+                mesh,
+                IOobject::NO_READ,
+                IOobject::NO_WRITE
+            ),
+            mesh,
+            dimensioned<tensor>("vdf", tensor::zero)
+        );
+        forAll(tvdf1, i)
+        {
+            tvdf1[i].xx() = 1 + 0.2*i;
+            tvdf1[i].yy() = 1 + 0.3*i;
+            tvdf1[i].zz() = 2 - 0.1*i;
+        }
+        VolatileDimensionedField<tensor, volMesh> tvdf2
+        (
+            IOobject
+            (
+                "vdf2",
+                runTime.timeName(),
+                mesh,
+                IOobject::NO_READ,
+                IOobject::NO_WRITE
+            ),
+            singleCell,
+            dimensioned<tensor>("vdf", initialTensor)
+        );
+        DimensionedField<tensor, volMesh> tdf1("tdf1", tvdf1);
+        DimensionedField<tensor, volMesh> tdf2
+        (
+            IOobject
+            (
+                "df2",
+                runTime.timeName(),
+                mesh,
+                IOobject::NO_READ,
+                IOobject::NO_WRITE
+            ),
+            mesh,
+            dimensioned<tensor>("vdf", initialTensor)
+        );
+        WHEN("Two volatile tensor fields are scalar-multiplied" )
+        {
+            auto tvdf3 = tvdf1 && tvdf2;
+            auto tdf3 = tdf1 && tdf2;
+            THEN("Operation result must match equivalent DimensionedField")
+            {
+                //forAll(tvdf3(), ci)
+                //{
+                //    Info << tvdf3()[ci] << nl << expectedTensor[ci] << nl;
+                //}
+                //std::vector<tensor> vt(tvdf3->begin(), tvdf3->end());
+                REQUIRE
+                (
+                    std::vector<tensor>(tvdf3->begin(), tvdf3->end())
+                    == std::vector<tensor>(tdf3->begin(), tdf3->end())
+                );
+            }
+        }
+        WHEN("Two volatile tensor fields are inner-multiplied" )
+        {
+            auto tvdf3 = tvdf1 & tvdf2;
+            auto tdf3 = tdf1 & tdf2;
+            THEN("Operation result must match equivalent DimensionedField")
+            {
+                //forAll(tvdf3(), ci)
+                //{
+                //    Info << tvdf3()[ci] << nl << expectedTensor[ci] << nl;
+                //}
+                //std::vector<tensor> vt(tvdf3->begin(), tvdf3->end());
+                REQUIRE
+                (
+                    std::vector<tensor>(tvdf3->begin(), tvdf3->end())
+                    == std::vector<tensor>(tdf3->begin(), tdf3->end())
+                );
+            }
+        }
+        vector initialVector { 1.1, 5.2, -3.3};
+        VolatileDimensionedField<vector, volMesh> vvdf1
+        (
+            IOobject
+            (
+                "vdf2",
+                runTime.timeName(),
+                mesh,
+                IOobject::NO_READ,
+                IOobject::NO_WRITE
+            ),
+            mesh,
+            dimensioned<vector>("vdf", vector::zero)
+        );
+        forAll(vvdf1, i)
+        {
+            vvdf1[i].x() = 1 + 0.2*i;
+            vvdf1[i].y() = 1 + 0.3*i;
+            vvdf1[i].z() = 2 - 0.1*i;
+        }
+        VolatileDimensionedField<vector, volMesh> vvdf2
+        (
+            IOobject
+            (
+                "vdf2",
+                runTime.timeName(),
+                mesh,
+                IOobject::NO_READ,
+                IOobject::NO_WRITE
+            ),
+            singleCell,
+            dimensioned<vector>("vdf", initialVector)
+        );
+        DimensionedField<vector, volMesh> vecdf1("vdf1", vvdf1);
+        DimensionedField<vector, volMesh> vecdf2
+        (
+            IOobject
+            (
+                "df2",
+                runTime.timeName(),
+                mesh,
+                IOobject::NO_READ,
+                IOobject::NO_WRITE
+            ),
+            mesh,
+            dimensioned<vector>("vdf", initialVector)
+        );
+
+        WHEN("Two volatile vector fields are outer-multiplied" )
+        {
+            auto vvdf3 = vvdf1 * vvdf2;
+            auto vdf3 = vecdf1 * vecdf2;
+            THEN("Operation result must match equivalent DimensionedField")
+            {
+                REQUIRE
+                (
+                    std::vector<tensor>(vvdf3->begin(), vvdf3->end())
+                    == std::vector<tensor>(vdf3->begin(), vdf3->end())
+                );
+            }
+        }
+        WHEN("Two volatile vector fields are cross-multiplied" )
+        {
+            auto vvdf3 = vvdf1 ^ vvdf2;
+            auto vdf3 = vecdf1 ^ vecdf2;
+            THEN("Operation result must match equivalent DimensionedField")
+            {
+                REQUIRE
+                (
+                    std::vector<vector>(vvdf3->begin(), vvdf3->end())
+                    == std::vector<vector>(vdf3->begin(), vdf3->end())
+                );
+            }
+        }
+    }
+}
+
+#undef TEST_VOLATILE_FIELD_BINARY_OP
+
+// ************************************************************************* //

--- a/tests/rsr/fields/VolatileOpsTraitsMTest.C
+++ b/tests/rsr/fields/VolatileOpsTraitsMTest.C
@@ -1,0 +1,91 @@
+#include <type_traits>
+#include <vector>
+#include "catch.H"
+#include "error.H"
+#include "fvCFD.H"
+#include "VolatileDimensionedFieldOpsTraitsM.H"
+#include "scalar.H"
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+#define CHECK_FUNCTIONS(T, opName, op, opFunc, func)                           \
+CHECK(decltype(opName##Helper::operator##opName##Works(res,a,b))::value == op);\
+CHECK(decltype(opName##Helper::opFunc##Works(res, a ,b))::value == func);      \
+REQUIRE_NOTHROW(opName##Helper::opFunc##Best(res, a, b))
+
+#define CHECH_FUNCTIONS_RETURN(T, opName, opFunc, syntax)                      \
+    using rT1 = std::remove_reference<decltype(syntax)>::type;                 \
+    using rT2 = std::remove_reference                                          \
+        <decltype(opName##Helper::opFunc##Best(res, a, b))>::type;             \
+    REQUIRE( std::is_same<rT1, rT2>::value )
+
+#define ADD_OPFUNC(T)                                                          \
+void add(T& res, const T& a, const T& b)                                       \
+{                                                                              \
+    add(static_cast<Field<scalar>&>(res), a, b);                               \
+}
+
+using namespace Foam;
+
+struct A { double a = 0; };
+A operator+(const A& aa, const A& bb)
+{
+    A res;
+    res.a = aa.a + bb.a;
+    return res;
+}
+
+struct B { double b = 1; };
+void add(B& res, const B& aa, const B& bb)
+{
+    res.b = aa.b + bb.b;
+}
+
+// Inherits from B and convertible to A
+struct C : public B
+{
+    double c = 2;
+    C() = default;
+    C(const A& aa) : c(aa.a) {}
+
+    operator A() { A a; a.a = c; return a; }
+};
+
+BEST_BINARY_PRODUCT(+, Plus, add, );
+
+SCENARIO("Functional traits for volatile fields")
+{
+    GIVEN("A set of sample classes")
+    {
+        WHEN("Only the syntax (res = x op y) works")
+        {
+            A res, a, b;
+            THEN("(x op y) is called when calling opFunc##Best()")
+            {
+                CHECK_FUNCTIONS(A, Plus, 1, add, 0);
+                CHECH_FUNCTIONS_RETURN(C, Plus, add, (res = a+b));
+            }
+        }
+        WHEN("Only the syntax opFunc(res, x, y) works")
+        {
+            B res, a, b;
+            THEN("opFunc(res, x, y) is called when calling opFunc##Best()")
+            {
+                CHECK_FUNCTIONS(B, Plus, 0, add, 1);
+                CHECH_FUNCTIONS_RETURN(C, Plus, add, add(res,a,b));
+            }
+        }
+        WHEN("A Class is convertible to classes that work with both functions")
+        {
+            C res, a, b;
+            res = a + b;
+            THEN("Using the operator syntax is preferred")
+            {
+                CHECK_FUNCTIONS(C, Plus, 1, add, 1);
+                CHECH_FUNCTIONS_RETURN(C, Plus, add, (res = a+b));
+            }
+        }
+    }
+}
+
+// ************************************************************************* //


### PR DESCRIPTION
- Requires C++14 standard library
- Introduces dimensioned fields that can be instantiated on a single-cell mesh and can be used to interact seamlessly with standard dimensioned fields.