### PR TITLE
Fix bug of incomplete volatile field types

### DIFF
--- a/src/rsr/fields/VolatileDimensionedFields/VolatileDimensionedField/VolatileDimensionedField.H
+++ b/src/rsr/fields/VolatileDimensionedFields/VolatileDimensionedField/VolatileDimensionedField.H
@@ -40,6 +40,7 @@ SourceFiles
 #define VolatileDimensionedField_H
 
 #include "DimensionedField.H"
+#include "surfaceMesh.H"
 #include "VolatileDimensionedFieldM.H"
 #include "products.H"
 


### PR DESCRIPTION
Closes #20 
- By making sure volatile fields are complete types when used in phase objects