### PR TITLE
Promote phases to database objects

### DIFF
--- a/src/rsr/phaseModels/phase/phase.C
+++ b/src/rsr/phaseModels/phase/phase.C
@@ -82,7 +82,7 @@ Foam::phase::phase
     const mixtureType& mT
 )
 :
-    regIOobject
+    objectRegistry
     (
         IOobject
         (
@@ -234,7 +234,17 @@ Foam::phase::phase
     const phase& ph
 )
 :
-    regIOobject(ph),
+    objectRegistry
+    (
+        IOobject
+        (
+            ph.name_,
+            ph.mesh_.time().timeName(),
+            ph.mesh_,
+            IOobject::NO_READ,
+            IOobject::NO_WRITE
+        )
+    ),
     name_(ph.name_),
     phaseDict_(ph.phaseDict_),
     mesh_(ph.mesh_),

--- a/src/rsr/phaseModels/phase/phase.H
+++ b/src/rsr/phaseModels/phase/phase.H
@@ -53,6 +53,7 @@ SourceFiles
 #include "FVFModel.H"
 #include "UniformityTypes.H"
 #include "singleCellFvMesh.H"
+#include "objectRegistry.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
@@ -68,7 +69,7 @@ enum class mixtureType { singlePhase, multiPhase };
 
 class phase
 :
-    public regIOobject
+    public objectRegistry
 {
 protected:
 


### PR DESCRIPTION
In preparation for relative permeability to be able to register themselves with  phases they interact with.